### PR TITLE
Updated the echo server code in readme for swift 3 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ class EchoServer {
 				
 				if bytesRead > 0 {
 					
-					guard let response = NSString(data: readData, encoding: NSUTF8StringEncoding) else {
+					guard let response = String(data: readData as Data, encoding: String.Encoding.utf8) else {
 						
 						print("Error decoding response...")
 						readData.length = 0

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ class EchoServer {
 				return
 			}
 			
-			try socket.listen(on: self.port, maxBacklog: 10)
+			try socket.listen(on: self.port, maxBacklogSize: 10)
 			
 			print("Listening on port: \(self.port)")
 			


### PR DESCRIPTION
After using the sample `EchoServer` program, I got a build error for `NSString(data: readData, encoding: NSUTF8StringEncoding)` and for `maxBacklog` parameter.

## Description
I created a new project with `swift-package-manager` and added `BlueSocket` in dependencies. I'm currently running swift version 3. After changing to `String(data: readData as Data, encoding: String.Encoding.utf8)` and `maxBacklog` to `maxBacklogSize` the example works perfectly.

## Motivation and Context
Solves the sample program build error on swift version 3 related to string encoding

## How Has This Been Tested?
Created a new project and ran the `EchoServer` program. The github repo is [BlueSocketTest](https://github.com/piyushchauhan2011/BlueSocketTest).

```bash
Apple Swift version 3.0 (swiftlang-800.0.33.1 clang-800.0.31)
Target: x86_64-apple-macosx10.9
```

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

Cheers,
Piyush Chauhan