### PR TITLE
Add support for non-blocking writes  to TCP sockets

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -1992,9 +1992,12 @@ public class Socket: SocketReader, SocketWriter {
 	///
 	/// - Parameters:
 	///		- buffer: 	The buffer containing the data to write.
-	/// 	- bufSize: 	The size of the buffer.
+    /// 	- bufSize: 	The size of the buffer.
+    ///
+    /// - Returns: Integer representing the number of bytes written.
 	///
-	public func write(from buffer: UnsafePointer<Void>, bufSize: Int) throws {
+    @discardableResult
+	public func write(from buffer: UnsafePointer<Void>, bufSize: Int) throws -> Int {
 		
 		// Make sure the buffer is valid...
 		if bufSize == 0 {
@@ -2047,57 +2050,71 @@ public class Socket: SocketReader, SocketWriter {
 				#endif
 			}
 			if s <= 0 {
+                if errno == EAGAIN && !isBlocking {
+                    // We have written out as much as we can
+                    return sent
+                }
 				
 				throw Error(code: Socket.SOCKET_ERR_WRITE_FAILED, reason: self.lastError())
 			}
 			sent += s
 		}
+        return sent
 	}
 	
 	///
 	/// Write data to the socket.
 	///
-	/// - Parameter data: The NSData object containing the data to write.
+    /// - Parameter data: The NSData object containing the data to write.
+    ///
+    /// - Returns: Integer representing the number of bytes written.
 	///
-	public func write(from data: NSData) throws {
+    @discardableResult
+	public func write(from data: NSData) throws -> Int {
 		
 		// If there's no data in the NSData object, why bother? Fail silently...
 		if data.length == 0 {
-			return
+			return 0
 		}
 		
-		try write(from: data.bytes, bufSize: data.length)
+		return try write(from: data.bytes, bufSize: data.length)
 	}
 	
 	///
 	/// Write data to the socket.
 	///
-	/// - Parameter data: The Data object containing the data to write.
+    /// - Parameter data: The Data object containing the data to write.
+    ///
+    /// - Returns: Integer representing the number of bytes written.
 	///
-	public func write(from data: Data) throws {
+    @discardableResult
+	public func write(from data: Data) throws -> Int {
 		
 		// If there's no data in the Data object, why bother? Fail silently...
 		if data.count == 0 {
-			return
+			return 0
 		}
 		
-		try data.withUnsafeBytes() { [unowned self] (buffer: UnsafePointer<UInt8>) throws in
+		return try data.withUnsafeBytes() { [unowned self] (buffer: UnsafePointer<UInt8>) throws -> Int in
 			
-			try self.write(from: buffer, bufSize: data.count)
+			return try self.write(from: buffer, bufSize: data.count)
 		}
 	}
 	
 	///
 	/// Write a string to the socket.
 	///
-	/// - Parameter string: The string to write.
+    /// - Parameter string: The string to write.
+    ///
+    /// - Returns: Integer representing the number of bytes written.
 	///
-	public func write(from string: String) throws {
+    @discardableResult
+	public func write(from string: String) throws -> Int {
 		
-		try string.nulTerminatedUTF8.withUnsafeBufferPointer() {
+		return try string.nulTerminatedUTF8.withUnsafeBufferPointer() { (buffer: UnsafeBufferPointer) -> Int in
 			
 			// The count returned by nullTerminatedUTF8 includes the null terminator...
-			try self.write(from: $0.baseAddress!, bufSize: $0.count-1)
+			return try self.write(from: buffer.baseAddress!, bufSize: buffer.count-1)
 		}
 	}
 	

--- a/Sources/SocketProtocols.swift
+++ b/Sources/SocketProtocols.swift
@@ -54,16 +54,22 @@ public protocol SocketWriter {
 	///
 	/// Writes data from NSData object.
 	///
-	/// - Parameter data: NSData object containing the data to be written.
+    /// - Parameter data: NSData object containing the data to be written.
+    ///
+    /// - Returns: Integer representing the number of bytes written.
 	///
-	func write(from data: NSData) throws
+    @discardableResult
+	func write(from data: NSData) throws -> Int
 	
 	///
 	/// Writes a string
 	///
-	/// - Parameter string: String data to be written.
+    /// - Parameter string: String data to be written.
+    ///
+    /// - Returns: Integer representing the number of bytes written.
 	///
-	func write(from string: String) throws
+    @discardableResult
+	func write(from string: String) throws -> Int
 }
 
 // MARK: SSLServiceDelegate


### PR DESCRIPTION
## Description
The various TCP write functions now return a discardable Int result that is the number of bytes written. These functions no longer throw an error if the write to the socket returned an error of EAGAIN and the socket had been set to non-blocking.

## Motivation and Context
BlueSocket supports non-blocking reads on TCP sockets. However it doesn't support non-blocking writes on TCP sockets as it throws an error if the write returns EAGAIN nor does it return the number of bytes written.

## How Has This Been Tested?
Using Kitura-net's tests

## Checklist:

- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
