### PR TITLE
Change project settings so that indentation uses tabs

### DIFF
--- a/BlueSocket.xcodeproj/project.pbxproj
+++ b/BlueSocket.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 				8C0F4BF71C4E84CC008B2B0A /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		8C0F4BF71C4E84CC008B2B0A /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
A project setting in Xcode standardizes the use of tabs instead of spaces for indentation across all files.

## Description
<!--- Describe your changes in detail -->
A single line changed in `project.pbxproj` to change the project settings. Also found in Xcode by clicking on the project in the Project navigator, and then selecting "Tabs" in the Text Settings pane in the File inspector.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When I began attempting to contribute, my editor was using spaces instead of tabs. I changed the project settings and figured this would be a useful change for all contributors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No tests, no code changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.