### PR TITLE
Move private initializer under proper heading

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -1028,7 +1028,7 @@ public class Socket: SocketReader, SocketWriter {
 	
 	// MARK: Lifecycle Methods
 	
-	// MARK: -- Public
+	// MARK: -- Private
 	
 	///
 	/// Internal initializer to create a configured Socket instance.
@@ -1072,27 +1072,7 @@ public class Socket: SocketReader, SocketWriter {
 			proto: sockProto.value,
 			address: nil)
 	}
-	
-	///
-	/// Cleanup: close the socket, free memory buffers.
-	///
-	deinit {
-		
-		if self.socketfd > 0 {
-			
-			self.close()
-		}
-		
-		// Destroy and free the readBuffer...
-		self.readBuffer.deinitialize()
-		self.readBuffer.deallocate(capacity: self.readBufferSize)
-		
-		// If we have a delegate, tell it to cleanup too...
-		self.delegate?.deinitialize()
-	}
-	
-	// MARK: -- Private
-	
+
 	///
 	/// Private constructor to create an instance for existing open socket fd.
 	///
@@ -1139,6 +1119,24 @@ public class Socket: SocketReader, SocketWriter {
 			}
 		}
 	}
+
+    ///
+    /// Cleanup: close the socket, free memory buffers.
+    ///
+    deinit {
+
+        if self.socketfd > 0 {
+
+            self.close()
+        }
+
+        // Destroy and free the readBuffer...
+        self.readBuffer.deinitialize()
+        self.readBuffer.deallocate(capacity: self.readBufferSize)
+
+        // If we have a delegate, tell it to cleanup too...
+        self.delegate?.deinitialize()
+    }
 	
 	// MARK: Public Methods
 	


### PR DESCRIPTION
This change changes the `MARK` heading for one of the initializers, removing the `MARK` for public lifecycle methods since nothing under that header qualified.

## Description
Since both `init` methods are private, and `deinit` is never called explicitly anyway, there shouldn't
really be any public lifecycle methods. Creation is handled by the public `create` class functions. I changed the `MARK: -- Public` at the top of the lifecycle methods section to `Private` from `Public`, deleted the `MARK: -- Private` a few lines down, and moved the `deinit` method to the bottom of the initializers.

## Motivation and Context
This is simply a change to keep the implementation in line with the documentation. The initializer is marked private and the documentation

## How Has This Been Tested?
No new functionality has been added, so coverage is provided by existing tests.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
