### PR TITLE
Add tests and helper functions for testing UDP read/write

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -302,7 +302,48 @@ public class Socket: SocketReader, SocketWriter {
 		
 		/// sockaddr_un
 		case unix(sockaddr_un)
-		
+
+		///
+		/// Creates an Address for a given host and port.
+		///
+		/// - Returns: An Address instance, or nil if the hostname and port are not valid.
+		///
+		init?(host: String, port: Int32) {
+			var info: UnsafeMutablePointer<addrinfo>? = UnsafeMutablePointer<addrinfo>.allocate(capacity: 1)
+
+			// Retrieve the info on our target...
+			var status: Int32 = getaddrinfo(host, String(port), nil, &info)
+			if status != 0 {
+
+				return nil
+			}
+
+			// Defer cleanup of our target info...
+			defer {
+
+				if info != nil {
+					freeaddrinfo(info)
+				}
+			}
+
+			var address: Address
+			if info!.pointee.ai_family == Int32(AF_INET) {
+
+				var addr = sockaddr_in()
+				memcpy(&addr, info!.pointee.ai_addr, Int(MemoryLayout<sockaddr_in>.size))
+				address = .ipv4(addr)
+
+			} else if info!.pointee.ai_family == Int32(AF_INET6) {
+
+				var addr = sockaddr_in6()
+				memcpy(&addr, info!.pointee.ai_addr, Int(MemoryLayout<sockaddr_in6>.size))
+				address = .ipv6(addr)
+			} else {
+				return nil
+			}
+			self = address
+		}
+
 		///
 		/// Size of address. (Readonly)
 		///


### PR DESCRIPTION
This PR adds a `testReadWriteUDP` test, as well as several helper functions.

## Description
This PR adds new methods in `SocketTests.swift` as follows:

`launchUDPHelper` spawns a thread containing a UDP server which will listen on port 1337 and respond to one packet sent.

`runUDPHelper` is the method which is actually run in the separate thread.

`testReadWriteUDP` is the actual tester method, which launches the helper, writes to the port, and then reads from the port.

Additionally, this PR adds a helper `init` in `Address` for creating an address from a hostname and port.

## Motivation and Context
Testing the UDP support is important and should be implemented ASAP. Additionally, since UDP is connectionless, we should have a method for easily creating `Address` objects on the fly.

## How Has This Been Tested?
Ran all tests in Xcode.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.