### PR TITLE
Always set MSG_NOSIGNAL to avoid process exit due to SIGPIPE

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -1234,17 +1234,16 @@ public class Socket: SocketReader, SocketWriter {
 			self.socketfd = Socket.SOCKET_INVALID_DESCRIPTOR
 			throw Error(code: Socket.SOCKET_ERR_UNABLE_TO_CREATE_SOCKET, reason: self.lastError())
 		}
-        
-        #if !os(Linux)
-            // Set the socket to ignore SIGPIPE to avoid dying on interrupted connections...
-            //	Note: Linux does not support the SO_NOSIGPIPE option. Instead, we use the
-            //		  MSG_NOSIGNAL flags passed to send.  See the write() functions below.
-            var on: Int32 = 1
-            if setsockopt(self.socketfd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size)) < 0 {
-                
-                throw Error(code: Socket.SOCKET_ERR_SETSOCKOPT_FAILED, reason: self.lastError())
-            }
-        #endif
+		
+		#if !os(Linux)
+			// Set the socket to ignore SIGPIPE to avoid dying on interrupted connections...
+			// Note: Linux does not support the SO_NOSIGPIPE option. Instead, we use the
+			// MSG_NOSIGNAL flags passed to send.  See the write() functions below.
+			var on: Int32 = 1
+			if setsockopt(self.socketfd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size)) < 0 {
+				throw Error(code: Socket.SOCKET_ERR_SETSOCKOPT_FAILED, reason: self.lastError())
+			}
+		#endif
 		
 		// Create the signature...
 		try self.signature = Signature(
@@ -1276,17 +1275,16 @@ public class Socket: SocketReader, SocketWriter {
 			let type = Int32(SOCK_STREAM.rawValue)
 		#else
 			let type = SOCK_STREAM
-
-            // Set the socket to ignore SIGPIPE to avoid dying on interrupted connections...
-            //	Note: Linux does not support the SO_NOSIGPIPE option. Instead, we use the
-            //		  MSG_NOSIGNAL flags passed to send.  See the write() functions below.
-            var on: Int32 = 1
-            if setsockopt(self.socketfd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size)) < 0 {
-                
-                throw Error(code: Socket.SOCKET_ERR_SETSOCKOPT_FAILED, reason: self.lastError())
-            }
-        #endif
-
+			
+			// Set the socket to ignore SIGPIPE to avoid dying on interrupted connections...
+			// Note: Linux does not support the SO_NOSIGPIPE option. Instead, we use the
+			// MSG_NOSIGNAL flags passed to send.  See the write() functions below.
+			var on: Int32 = 1
+			if setsockopt(self.socketfd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size)) < 0 {
+				throw Error(code: Socket.SOCKET_ERR_SETSOCKOPT_FAILED, reason: self.lastError())
+			}
+		#endif
+		
 		if path != nil {
 			
 			try self.signature = Signature(socketType: .stream, proto: .unix, path: path)
@@ -2843,8 +2841,8 @@ public class Socket: SocketReader, SocketWriter {
 		var sent = 0
 		var sendFlags: Int32 = 0
 		#if os(Linux)
-            // Ignore SIGPIPE to avoid process termination if the reader has closed the connection.
-            // On Linux, we set the MSG_NOSIGNAL send flag. On OSX, we set SO_NOSIGPIPE during init().
+			// Ignore SIGPIPE to avoid process termination if the reader has closed the connection.
+			// On Linux, we set the MSG_NOSIGNAL send flag. On OSX, we set SO_NOSIGPIPE during init().
 			sendFlags = Int32(MSG_NOSIGNAL)
 		#endif
 		while sent < bufSize {
@@ -3009,8 +3007,8 @@ public class Socket: SocketReader, SocketWriter {
 		var sent = 0
 		var sendFlags: Int32 = 0
 		#if os(Linux)
-            // Ignore SIGPIPE to avoid process termination if the reader has closed the connection.
-            // On Linux, we set the MSG_NOSIGNAL send flag. On OSX, we set SO_NOSIGPIPE during init().
+			// Ignore SIGPIPE to avoid process termination if the reader has closed the connection.
+			// On Linux, we set the MSG_NOSIGNAL send flag. On OSX, we set SO_NOSIGPIPE during init().
 			sendFlags = Int32(MSG_NOSIGNAL)
 		#endif
 		

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -2843,9 +2843,7 @@ public class Socket: SocketReader, SocketWriter {
 		var sent = 0
 		var sendFlags: Int32 = 0
 		#if os(Linux)
-			if self.isListening {
-				sendFlags = Int32(MSG_NOSIGNAL)
-			}
+			sendFlags = Int32(MSG_NOSIGNAL)
 		#endif
 		while sent < bufSize {
 			
@@ -3009,9 +3007,7 @@ public class Socket: SocketReader, SocketWriter {
 		var sent = 0
 		var sendFlags: Int32 = 0
 		#if os(Linux)
-			if self.isListening {
-				sendFlags = Int32(MSG_NOSIGNAL)
-			}
+			sendFlags = Int32(MSG_NOSIGNAL)
 		#endif
 		
 		var addr = address.addr


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change always sets the `MSG_NOSIGNAL` flag when writing to a socket, rather than only when the socket `isListening`.  This avoids an unexpected process exit if a `SIGPIPE` occurs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was investigating a problem where Kitura occasionally exits with no error message when I drive load.  I checked the return code, which was 141 (128 + 13 which is `SIGPIPE`).  It seems we do not handle the `SIGPIPE`, but nor do we suppress it.
This is intended to fix IBM-Swift/Kitura#965

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The Socket tests passed.
Kitura works correctly under load, and now correctly logs a `Broken pipe` error, rather than exiting.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
