### PR TITLE
Memory leak from address pointer allocation 

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -1157,7 +1157,7 @@ public class Socket: SocketReader, SocketWriter {
 	///
 	public class func createAddress(for host: String, on port: Int32) -> Address? {
 		
-		var info: UnsafeMutablePointer<addrinfo>? = UnsafeMutablePointer<addrinfo>.allocate(capacity: 1)
+		var info: UnsafeMutablePointer<addrinfo>?
 		
 		// Retrieve the info on our target...
 		var status: Int32 = getaddrinfo(host, String(port), nil, &info)
@@ -1700,7 +1700,7 @@ public class Socket: SocketReader, SocketWriter {
 				ai_next: nil)
 		#endif
 		
-		var targetInfo: UnsafeMutablePointer<addrinfo>? = UnsafeMutablePointer<addrinfo>.allocate(capacity: 1)
+		var targetInfo: UnsafeMutablePointer<addrinfo>?
 		
 		// Retrieve the info on our target...
 		var status: Int32 = getaddrinfo(host, String(port), &hints, &targetInfo)
@@ -2056,7 +2056,7 @@ public class Socket: SocketReader, SocketWriter {
 				ai_next: nil)
 		#endif
 		
-		var targetInfo: UnsafeMutablePointer<addrinfo>? = UnsafeMutablePointer<addrinfo>.allocate(capacity: 1)
+		var targetInfo: UnsafeMutablePointer<addrinfo>?
 		
 		// Retrieve the info on our target...
 		let status: Int32 = getaddrinfo(nil, String(port), &hints, &targetInfo)


### PR DESCRIPTION
## Description
Memory leak of `addrinfo` allocation present every time `UnsafeMutablePointer<addrinfo>.allocate(capacity: 1)` is called. Every call leaks an additional 48 bytes.

## Motivation and Context
`getaddrinfo()` handles memory allocation to the pointer which is released upon `freeaddrinfo()` however the original allocation from `.allocate(capacity:)` is unallocated and leaked (ARC is not responsible for deallocation of pointers).

Leak is present when run through Xcode Instruments. With pull changes, Instruments no longer reports leak.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)