### PR TITLE
Allow port sharing between ipv4 and ipv6

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -2015,7 +2015,15 @@ public class Socket: SocketReader, SocketWriter {
 			
 			throw Error(code: Socket.SOCKET_ERR_INTERNAL, reason: "Socket signature not found.")
 		}
-		
+
+        // Configure ipv6 socket so that it can share ports with ipv4 on the same port.
+        if sig.protocolFamily == .inet6 && sig.proto == .tcp {
+            if setsockopt(self.socketfd, Int32(IPPROTO_IPV6), IPV6_V6ONLY, &on, socklen_t(MemoryLayout<Int32>.size)) < 0 {
+
+                throw Error(code: Socket.SOCKET_ERR_SETSOCKOPT_FAILED, reason: self.lastError())
+            }
+        }
+
 		// No SSL over UDP...
 		if sig.socketType != .datagram && sig.proto != .udp {
 


### PR DESCRIPTION
## Description
Enabling `IPV6_V6ONLY` on ipv6 listening sockets allows sharing the port with ipv4. This allows one for example to listen on both ipv4 and ipv6 on port 8000.

## How Has This Been Tested?
Tested on macOS 10.12.3 and Ubuntu 16.04.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
