### PR TITLE
Set SO_REUSEPORT for port sharing on OSX

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -2020,7 +2020,15 @@ public class Socket: SocketReader, SocketWriter {
 			
 			throw Error(code: Socket.SOCKET_ERR_SETSOCKOPT_FAILED, reason: self.lastError())
 		}
-		
+
+        // SO_REUSEPORT allows completely duplicate bindings by multiple processes if they 
+        // all set SO_REUSEPORT before binding the port.  This option permits multiple
+        // instances of a program to each receive UDP/IP multicast or broadcast datagrams 
+        // destined for the bound port.
+        if setsockopt(self.socketfd, SOL_SOCKET, SO_REUSEPORT, &on, socklen_t(MemoryLayout<Int32>.size)) < 0 {
+            throw Error(code: Socket.SOCKET_ERR_SETSOCKOPT_FAILED, reason: self.lastError())
+        }
+
 		// Get the signature for the socket...
 		guard let sig = self.signature else {
 			


### PR DESCRIPTION
Follow-up on #60; need to set SO_REUSEPORT in order to share (UDP) ports on OSX.

## How Has This Been Tested?
Tested on macOS 10.12.4 and Ubuntu 16.04.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
