### PR TITLE
Fix issue in Swift trunk dev 5/10 snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .build
 .DS_Store
-Socket.xcodeproj

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build
 .DS_Store
+Socket.xcodeproj

--- a/Sources/SocketUtils.swift
+++ b/Sources/SocketUtils.swift
@@ -400,7 +400,7 @@ public extension sockaddr_un {
 		public static func SET(fd: Int32, set: inout fd_set) {
 			let intOffset = Int(fd / 32)
 			let bitOffset = fd % 32
-			let mask = 1 << bitOffset
+			let mask = Int32(1 << bitOffset)
 			switch intOffset {
 			case 0: set.fds_bits.0 = set.fds_bits.0 | mask
 			case 1: set.fds_bits.1 = set.fds_bits.1 | mask
@@ -444,7 +444,7 @@ public extension sockaddr_un {
 		public static func CLR(fd: Int32, set: inout fd_set) {
 			let intOffset = Int(fd / 32)
 			let bitOffset = fd % 32
-			let mask = ~(1 << bitOffset)
+			let mask = Int32(~(1 << bitOffset))
 			switch intOffset {
 			case 0: set.fds_bits.0 = set.fds_bits.0 & mask
 			case 1: set.fds_bits.1 = set.fds_bits.1 & mask
@@ -488,7 +488,7 @@ public extension sockaddr_un {
 		public static func ISSET(fd: Int32, set: inout fd_set) -> Bool {
 			let intOffset = Int(fd / 32)
 			let bitOffset = fd % 32
-			let mask = 1 << bitOffset
+			let mask = Int32(1 << bitOffset)
 			switch intOffset {
 			case 0: return set.fds_bits.0 & mask != 0
 			case 1: return set.fds_bits.1 & mask != 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
https://swift.org/download/#snapshots
In this snapshot (which I am using to test new JSONEncoder features), `Int` and `Int32` cannot be `|`'d. So I am casting `mask` to `Int32`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on macOS Xcode 8.3.2 toolchain, 3.1.1 RELEASE, and the trunk dev snapshot aforementioned. Not tested in Linux.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
