### PR TITLE
Update podspec to allow for watchOS and tvOS too

### DIFF
--- a/BlueSocket.podspec
+++ b/BlueSocket.podspec
@@ -10,6 +10,8 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.osx.deployment_target = "10.11"
   s.ios.deployment_target = "10.0"
+  s.watchos.deployment_target = "3.0"
+  s.tvos.deployment_target = "10.0"
   s.source   = { :git => "https://github.com/IBM-Swift/BlueSocket.git", :tag => s.version }
   s.source_files = "Sources/*.swift"
   s.pod_target_xcconfig =  {


### PR DESCRIPTION
Allow Podspec to compile for watchOS and tvOS too

Please do a "pod trunk push" after merging the changes (will possibly need a version bump too)

- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
