### PR TITLE
Fixed a build error for iOS target due to incorrect Info.plist path

### DIFF
--- a/BlueSocket.xcodeproj/project.pbxproj
+++ b/BlueSocket.xcodeproj/project.pbxproj
@@ -512,7 +512,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Socket/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
@@ -536,7 +536,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Socket/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
## Description
I just upgraded to 0.12.64 release, and is unable to compile the iOS target.
The error points to Info.plist missing in iOS target due to the file has been moved from `$(SRCROOT)/Sources/Info.plist` to `$(SRCROOT)/Sources/Socket/Info.plist`

## Motivation and Context
This PR fixes compiling error of  BlueSocket-iOS  due to missing Info.plist.

## How Has This Been Tested?
Successfully compiled with Xcode 9 ß6

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.