### PR TITLE
fix for FD runtime errors with bitmask

### DIFF
--- a/BlueSocket.podspec
+++ b/BlueSocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "BlueSocket"
-  s.version     = "0.12.70"
+  s.version     = "0.12.71"
   s.summary     = "Socket framework for Swift using the Swift Package Manager"
   s.homepage    = "https://github.com/IBM-Swift/BlueSocket"
   s.license     = { :type => "Apache License, Version 2.0" }

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-midnight

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-midnight


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Constructor of Int32 throws error on operation **Int32(1 << 31)**.
**fd_set** uses **Int32** so to clarify things it is used everywhere. 

## Motivation and Context
We've been experiencing errors due to this bug and after Swift 4 it started showing all the time so we were forced to fork repository. Right now 50+ users are sending us those errors.

## How Has This Been Tested?
iPhone: 7 Plus, 7, SE, 5c, 5s
iOS: 10.3.3, 10.3.2, 11.0.0, 11.0.1, 10.2.1
Library version: >= 0.12.61
Swift version: 4.0
Xcode version: 9.0 build 9A235
