### PR TITLE
Allow wait to work for udp sockets

### DIFF
--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -1091,10 +1091,6 @@ public class Socket: SocketReader, SocketWriter {
 
 				throw Error(code: Socket.SOCKET_ERR_BAD_DESCRIPTOR, reason: nil)
 			}
-			if !socket.isActive {
-
-				throw Error(code: Socket.SOCKET_ERR_NOT_ACTIVE, reason: nil)
-			}
 		}
 
 		// Setup the timeout...


### PR DESCRIPTION
## Description
- Remove check for `isActive` in wait
- Listening isnt set in udp sockets so it is never 'active'
- Its valid to wait for data on udp sockets that are bound

## Motivation and Context
- Its valid to wait for data on udp sockets but the removed check doesnt allow the library to do it

## How Has This Been Tested?
I was going to write a test, but having read the CLA, I don't want to anymore. Hopefully you will be able to copy, or improve upon this trivial change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
