### PR TITLE
A few cleanups and one bug fix:

### DIFF
--- a/Sources/Socket/SocketUtils.swift
+++ b/Sources/Socket/SocketUtils.swift
@@ -112,387 +112,66 @@ extension Socket.Address {
 	}
 }
 
-#if arch(arm) && os(Linux)
+#if os(Linux)
 	
-	public struct FD {
-		
-		/// Replacement for FD_ZERO macro
-		
-		public static func ZERO(set: inout fd_set) {
-			set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-		}
-		
-		
-		/// Replacement for FD_SET macro
-		
-		public static func SET(fd: Int32, set: inout fd_set) {
-			let intOffset = Int32(fd / 32)
-			let bitOffset: Int32 = Int32(fd % 32)
-			let mask: Int32 = 1 << bitOffset
-			switch intOffset {
-			case 0: set.__fds_bits.0 = set.__fds_bits.0 | mask
-			case 1: set.__fds_bits.1 = set.__fds_bits.1 | mask
-			case 2: set.__fds_bits.2 = set.__fds_bits.2 | mask
-			case 3: set.__fds_bits.3 = set.__fds_bits.3 | mask
-			case 4: set.__fds_bits.4 = set.__fds_bits.4 | mask
-			case 5: set.__fds_bits.5 = set.__fds_bits.5 | mask
-			case 6: set.__fds_bits.6 = set.__fds_bits.6 | mask
-			case 7: set.__fds_bits.7 = set.__fds_bits.7 | mask
-			case 8: set.__fds_bits.8 = set.__fds_bits.8 | mask
-			case 9: set.__fds_bits.9 = set.__fds_bits.9 | mask
-			case 10: set.__fds_bits.10 = set.__fds_bits.10 | mask
-			case 11: set.__fds_bits.11 = set.__fds_bits.11 | mask
-			case 12: set.__fds_bits.12 = set.__fds_bits.12 | mask
-			case 13: set.__fds_bits.13 = set.__fds_bits.13 | mask
-			case 14: set.__fds_bits.14 = set.__fds_bits.14 | mask
-			case 15: set.__fds_bits.15 = set.__fds_bits.15 | mask
-			case 16: set.__fds_bits.16 = set.__fds_bits.16 | mask
-			case 17: set.__fds_bits.17 = set.__fds_bits.17 | mask
-			case 18: set.__fds_bits.18 = set.__fds_bits.18 | mask
-			case 19: set.__fds_bits.19 = set.__fds_bits.19 | mask
-			case 20: set.__fds_bits.20 = set.__fds_bits.20 | mask
-			case 21: set.__fds_bits.21 = set.__fds_bits.21 | mask
-			case 22: set.__fds_bits.22 = set.__fds_bits.22 | mask
-			case 23: set.__fds_bits.23 = set.__fds_bits.23 | mask
-			case 24: set.__fds_bits.24 = set.__fds_bits.24 | mask
-			case 25: set.__fds_bits.25 = set.__fds_bits.25 | mask
-			case 26: set.__fds_bits.26 = set.__fds_bits.26 | mask
-			case 27: set.__fds_bits.27 = set.__fds_bits.27 | mask
-			case 28: set.__fds_bits.28 = set.__fds_bits.28 | mask
-			case 29: set.__fds_bits.29 = set.__fds_bits.29 | mask
-			case 30: set.__fds_bits.20 = set.__fds_bits.30 | mask
-			case 31: set.__fds_bits.31 = set.__fds_bits.31 | mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_CLR macro
-		
-		public static func CLR(fd: Int32, set: inout fd_set) {
-			let intOffset = Int32(fd / 32)
-			let bitOffset: Int32 = Int32(fd % 32)
-			let mask: Int32 = ~(1 << bitOffset)
-			switch intOffset {
-			case 0: set.__fds_bits.0 = set.__fds_bits.0 & mask
-			case 1: set.__fds_bits.1 = set.__fds_bits.1 & mask
-			case 2: set.__fds_bits.2 = set.__fds_bits.2 & mask
-			case 3: set.__fds_bits.3 = set.__fds_bits.3 & mask
-			case 4: set.__fds_bits.4 = set.__fds_bits.4 & mask
-			case 5: set.__fds_bits.5 = set.__fds_bits.5 & mask
-			case 6: set.__fds_bits.6 = set.__fds_bits.6 & mask
-			case 7: set.__fds_bits.7 = set.__fds_bits.7 & mask
-			case 8: set.__fds_bits.8 = set.__fds_bits.8 & mask
-			case 9: set.__fds_bits.9 = set.__fds_bits.9 & mask
-			case 10: set.__fds_bits.10 = set.__fds_bits.10 & mask
-			case 11: set.__fds_bits.11 = set.__fds_bits.11 & mask
-			case 12: set.__fds_bits.12 = set.__fds_bits.12 & mask
-			case 13: set.__fds_bits.13 = set.__fds_bits.13 & mask
-			case 14: set.__fds_bits.14 = set.__fds_bits.14 & mask
-			case 15: set.__fds_bits.15 = set.__fds_bits.15 & mask
-			case 16: set.__fds_bits.16 = set.__fds_bits.16 & mask
-			case 17: set.__fds_bits.17 = set.__fds_bits.17 & mask
-			case 18: set.__fds_bits.18 = set.__fds_bits.18 & mask
-			case 19: set.__fds_bits.19 = set.__fds_bits.19 & mask
-			case 20: set.__fds_bits.20 = set.__fds_bits.20 & mask
-			case 21: set.__fds_bits.21 = set.__fds_bits.21 & mask
-			case 22: set.__fds_bits.22 = set.__fds_bits.22 & mask
-			case 23: set.__fds_bits.23 = set.__fds_bits.23 & mask
-			case 24: set.__fds_bits.24 = set.__fds_bits.24 & mask
-			case 25: set.__fds_bits.25 = set.__fds_bits.25 & mask
-			case 26: set.__fds_bits.26 = set.__fds_bits.26 & mask
-			case 27: set.__fds_bits.27 = set.__fds_bits.27 & mask
-			case 28: set.__fds_bits.28 = set.__fds_bits.28 & mask
-			case 29: set.__fds_bits.29 = set.__fds_bits.29 & mask
-			case 30: set.__fds_bits.20 = set.__fds_bits.30 & mask
-			case 31: set.__fds_bits.31 = set.__fds_bits.31 & mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_ISSET macro
-		
-		public static func ISSET(fd: Int32, set: inout fd_set) -> Bool {
-			let intOffset = Int32(fd / 32)
-			let bitOffset = Int32(fd % 32)
-			let mask: Int32 = 1 << bitOffset
-			switch intOffset {
-			case 0: return set.__fds_bits.0 & mask != 0
-			case 1: return set.__fds_bits.1 & mask != 0
-			case 2: return set.__fds_bits.2 & mask != 0
-			case 3: return set.__fds_bits.3 & mask != 0
-			case 4: return set.__fds_bits.4 & mask != 0
-			case 5: return set.__fds_bits.5 & mask != 0
-			case 6: return set.__fds_bits.6 & mask != 0
-			case 7: return set.__fds_bits.7 & mask != 0
-			case 8: return set.__fds_bits.8 & mask != 0
-			case 9: return set.__fds_bits.9 & mask != 0
-			case 10: return set.__fds_bits.10 & mask != 0
-			case 11: return set.__fds_bits.11 & mask != 0
-			case 12: return set.__fds_bits.12 & mask != 0
-			case 13: return set.__fds_bits.13 & mask != 0
-			case 14: return set.__fds_bits.14 & mask != 0
-			case 15: return set.__fds_bits.15 & mask != 0
-			case 16: return set.__fds_bits.16 & mask != 0
-			case 17: return set.__fds_bits.17 & mask != 0
-			case 18: return set.__fds_bits.18 & mask != 0
-			case 19: return set.__fds_bits.19 & mask != 0
-			case 20: return set.__fds_bits.20 & mask != 0
-			case 21: return set.__fds_bits.21 & mask != 0
-			case 22: return set.__fds_bits.22 & mask != 0
-			case 23: return set.__fds_bits.23 & mask != 0
-			case 24: return set.__fds_bits.24 & mask != 0
-			case 25: return set.__fds_bits.25 & mask != 0
-			case 26: return set.__fds_bits.26 & mask != 0
-			case 27: return set.__fds_bits.27 & mask != 0
-			case 28: return set.__fds_bits.28 & mask != 0
-			case 29: return set.__fds_bits.29 & mask != 0
-			case 30: return set.__fds_bits.30 & mask != 0
-			case 31: return set.__fds_bits.31 & mask != 0
-			default: return false
-			}
-			
-		}
-	}
+	#if arch(arm)
+		let __fd_set_count = 16
+	#else
+		let __fd_set_count = 32
+	#endif
 	
-#elseif os(Linux)
-	
-	public struct FD {
-		
-		/// Replacement for FD_ZERO macro
-		
-		public static func ZERO(set: inout fd_set) {
-			set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-		}
-		
-		
-		/// Replacement for FD_SET macro
-		
-		public static func SET(fd: Int32, set: inout fd_set) {
-			let intOffset = Int(fd / 16)
-			let bitOffset: Int = Int(fd % 16)
-			let mask: Int = 1 << bitOffset
-			switch intOffset {
-			case 0: set.__fds_bits.0 = set.__fds_bits.0 | mask
-			case 1: set.__fds_bits.1 = set.__fds_bits.1 | mask
-			case 2: set.__fds_bits.2 = set.__fds_bits.2 | mask
-			case 3: set.__fds_bits.3 = set.__fds_bits.3 | mask
-			case 4: set.__fds_bits.4 = set.__fds_bits.4 | mask
-			case 5: set.__fds_bits.5 = set.__fds_bits.5 | mask
-			case 6: set.__fds_bits.6 = set.__fds_bits.6 | mask
-			case 7: set.__fds_bits.7 = set.__fds_bits.7 | mask
-			case 8: set.__fds_bits.8 = set.__fds_bits.8 | mask
-			case 9: set.__fds_bits.9 = set.__fds_bits.9 | mask
-			case 10: set.__fds_bits.10 = set.__fds_bits.10 | mask
-			case 11: set.__fds_bits.11 = set.__fds_bits.11 | mask
-			case 12: set.__fds_bits.12 = set.__fds_bits.12 | mask
-			case 13: set.__fds_bits.13 = set.__fds_bits.13 | mask
-			case 14: set.__fds_bits.14 = set.__fds_bits.14 | mask
-			case 15: set.__fds_bits.15 = set.__fds_bits.15 | mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_CLR macro
-		
-		public static func CLR(fd: Int32, set: inout fd_set) {
-			let intOffset = Int(fd / 16)
-			let bitOffset: Int = Int(fd % 16)
-			let mask: Int = ~(1 << bitOffset)
-			switch intOffset {
-			case 0: set.__fds_bits.0 = set.__fds_bits.0 & mask
-			case 1: set.__fds_bits.1 = set.__fds_bits.1 & mask
-			case 2: set.__fds_bits.2 = set.__fds_bits.2 & mask
-			case 3: set.__fds_bits.3 = set.__fds_bits.3 & mask
-			case 4: set.__fds_bits.4 = set.__fds_bits.4 & mask
-			case 5: set.__fds_bits.5 = set.__fds_bits.5 & mask
-			case 6: set.__fds_bits.6 = set.__fds_bits.6 & mask
-			case 7: set.__fds_bits.7 = set.__fds_bits.7 & mask
-			case 8: set.__fds_bits.8 = set.__fds_bits.8 & mask
-			case 9: set.__fds_bits.9 = set.__fds_bits.9 & mask
-			case 10: set.__fds_bits.10 = set.__fds_bits.10 & mask
-			case 11: set.__fds_bits.11 = set.__fds_bits.11 & mask
-			case 12: set.__fds_bits.12 = set.__fds_bits.12 & mask
-			case 13: set.__fds_bits.13 = set.__fds_bits.13 & mask
-			case 14: set.__fds_bits.14 = set.__fds_bits.14 & mask
-			case 15: set.__fds_bits.15 = set.__fds_bits.15 & mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_ISSET macro
-		
-		public static func ISSET(fd: Int32, set: inout fd_set) -> Bool {
-			let intOffset = Int(fd / 16)
-			let bitOffset = Int(fd % 16)
-			let mask: Int = 1 << bitOffset
-			switch intOffset {
-			case 0: return set.__fds_bits.0 & mask != 0
-			case 1: return set.__fds_bits.1 & mask != 0
-			case 2: return set.__fds_bits.2 & mask != 0
-			case 3: return set.__fds_bits.3 & mask != 0
-			case 4: return set.__fds_bits.4 & mask != 0
-			case 5: return set.__fds_bits.5 & mask != 0
-			case 6: return set.__fds_bits.6 & mask != 0
-			case 7: return set.__fds_bits.7 & mask != 0
-			case 8: return set.__fds_bits.8 & mask != 0
-			case 9: return set.__fds_bits.9 & mask != 0
-			case 10: return set.__fds_bits.10 & mask != 0
-			case 11: return set.__fds_bits.11 & mask != 0
-			case 12: return set.__fds_bits.12 & mask != 0
-			case 13: return set.__fds_bits.13 & mask != 0
-			case 14: return set.__fds_bits.14 & mask != 0
-			case 15: return set.__fds_bits.15 & mask != 0
-			default: return false
+	extension fd_set
+	{
+		@inline(__always)
+		mutating func withCArrayAccess<T>(block: (UnsafeMutablePointer<Int32>) throws -> T) rethrows -> T {
+			return try withUnsafeMutablePointer(to: &__fds_bits) {
+				try block(UnsafeMutableRawPointer($0).assumingMemoryBound(to: Int32.self))
 			}
 		}
 	}
 	
-#else
+#else   // not Linux on ARM
 	
-	public struct FD {
-		
-		/// Replacement for FD_ZERO macro
-		
-		public static func ZERO(set: inout fd_set) {
-			set.fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-		}
-		
-		
-		/// Replacement for FD_SET macro
-		
-		public static func SET(fd: Int32, set: inout fd_set) {
-			let intOffset = Int32(fd / 32)
-			let bitOffset = fd % 32
-			let mask: Int32 = 1 << bitOffset
-			switch intOffset {
-			case 0: set.fds_bits.0 = set.fds_bits.0 | mask
-			case 1: set.fds_bits.1 = set.fds_bits.1 | mask
-			case 2: set.fds_bits.2 = set.fds_bits.2 | mask
-			case 3: set.fds_bits.3 = set.fds_bits.3 | mask
-			case 4: set.fds_bits.4 = set.fds_bits.4 | mask
-			case 5: set.fds_bits.5 = set.fds_bits.5 | mask
-			case 6: set.fds_bits.6 = set.fds_bits.6 | mask
-			case 7: set.fds_bits.7 = set.fds_bits.7 | mask
-			case 8: set.fds_bits.8 = set.fds_bits.8 | mask
-			case 9: set.fds_bits.9 = set.fds_bits.9 | mask
-			case 10: set.fds_bits.10 = set.fds_bits.10 | mask
-			case 11: set.fds_bits.11 = set.fds_bits.11 | mask
-			case 12: set.fds_bits.12 = set.fds_bits.12 | mask
-			case 13: set.fds_bits.13 = set.fds_bits.13 | mask
-			case 14: set.fds_bits.14 = set.fds_bits.14 | mask
-			case 15: set.fds_bits.15 = set.fds_bits.15 | mask
-			case 16: set.fds_bits.16 = set.fds_bits.16 | mask
-			case 17: set.fds_bits.17 = set.fds_bits.17 | mask
-			case 18: set.fds_bits.18 = set.fds_bits.18 | mask
-			case 19: set.fds_bits.19 = set.fds_bits.19 | mask
-			case 20: set.fds_bits.20 = set.fds_bits.20 | mask
-			case 21: set.fds_bits.21 = set.fds_bits.21 | mask
-			case 22: set.fds_bits.22 = set.fds_bits.22 | mask
-			case 23: set.fds_bits.23 = set.fds_bits.23 | mask
-			case 24: set.fds_bits.24 = set.fds_bits.24 | mask
-			case 25: set.fds_bits.25 = set.fds_bits.25 | mask
-			case 26: set.fds_bits.26 = set.fds_bits.26 | mask
-			case 27: set.fds_bits.27 = set.fds_bits.27 | mask
-			case 28: set.fds_bits.28 = set.fds_bits.28 | mask
-			case 29: set.fds_bits.29 = set.fds_bits.29 | mask
-			case 30: set.fds_bits.30 = set.fds_bits.30 | mask
-			case 31: set.fds_bits.31 = set.fds_bits.31 | mask
-			default: break
+	let __fd_set_count = Int(__DARWIN_FD_SETSIZE) / MemoryLayout<Int32>.stride
+	
+	extension fd_set
+	{
+		@inline(__always)
+		mutating func withCArrayAccess<T>(block: (UnsafeMutablePointer<Int32>) throws -> T) rethrows -> T {
+			return try withUnsafeMutablePointer(to: &fds_bits) {
+				try block(UnsafeMutableRawPointer($0).assumingMemoryBound(to: Int32.self))
 			}
-		}
-		
-		
-		/// Replacement for FD_CLR macro
-		
-		public static func CLR(fd: Int32, set: inout fd_set) {
-			let intOffset = Int32(fd / 32)
-			let bitOffset = fd % 32
-			let mask: Int32 = ~(1 << bitOffset)
-			switch intOffset {
-			case 0: set.fds_bits.0 = set.fds_bits.0 & mask
-			case 1: set.fds_bits.1 = set.fds_bits.1 & mask
-			case 2: set.fds_bits.2 = set.fds_bits.2 & mask
-			case 3: set.fds_bits.3 = set.fds_bits.3 & mask
-			case 4: set.fds_bits.4 = set.fds_bits.4 & mask
-			case 5: set.fds_bits.5 = set.fds_bits.5 & mask
-			case 6: set.fds_bits.6 = set.fds_bits.6 & mask
-			case 7: set.fds_bits.7 = set.fds_bits.7 & mask
-			case 8: set.fds_bits.8 = set.fds_bits.8 & mask
-			case 9: set.fds_bits.9 = set.fds_bits.9 & mask
-			case 10: set.fds_bits.10 = set.fds_bits.10 & mask
-			case 11: set.fds_bits.11 = set.fds_bits.11 & mask
-			case 12: set.fds_bits.12 = set.fds_bits.12 & mask
-			case 13: set.fds_bits.13 = set.fds_bits.13 & mask
-			case 14: set.fds_bits.14 = set.fds_bits.14 & mask
-			case 15: set.fds_bits.15 = set.fds_bits.15 & mask
-			case 16: set.fds_bits.16 = set.fds_bits.16 & mask
-			case 17: set.fds_bits.17 = set.fds_bits.17 & mask
-			case 18: set.fds_bits.18 = set.fds_bits.18 & mask
-			case 19: set.fds_bits.19 = set.fds_bits.19 & mask
-			case 20: set.fds_bits.20 = set.fds_bits.20 & mask
-			case 21: set.fds_bits.21 = set.fds_bits.21 & mask
-			case 22: set.fds_bits.22 = set.fds_bits.22 & mask
-			case 23: set.fds_bits.23 = set.fds_bits.23 & mask
-			case 24: set.fds_bits.24 = set.fds_bits.24 & mask
-			case 25: set.fds_bits.25 = set.fds_bits.25 & mask
-			case 26: set.fds_bits.26 = set.fds_bits.26 & mask
-			case 27: set.fds_bits.27 = set.fds_bits.27 & mask
-			case 28: set.fds_bits.28 = set.fds_bits.28 & mask
-			case 29: set.fds_bits.29 = set.fds_bits.29 & mask
-			case 30: set.fds_bits.30 = set.fds_bits.30 & mask
-			case 31: set.fds_bits.31 = set.fds_bits.31 & mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_ISSET macro
-		
-		public static func ISSET(fd: Int32, set: inout fd_set) -> Bool {
-			let intOffset = Int32(fd / 32)
-			let bitOffset = fd % 32
-			let mask: Int32 = 1 << bitOffset
-			switch intOffset {
-			case 0: return set.fds_bits.0 & mask != 0
-			case 1: return set.fds_bits.1 & mask != 0
-			case 2: return set.fds_bits.2 & mask != 0
-			case 3: return set.fds_bits.3 & mask != 0
-			case 4: return set.fds_bits.4 & mask != 0
-			case 5: return set.fds_bits.5 & mask != 0
-			case 6: return set.fds_bits.6 & mask != 0
-			case 7: return set.fds_bits.7 & mask != 0
-			case 8: return set.fds_bits.8 & mask != 0
-			case 9: return set.fds_bits.9 & mask != 0
-			case 10: return set.fds_bits.10 & mask != 0
-			case 11: return set.fds_bits.11 & mask != 0
-			case 12: return set.fds_bits.12 & mask != 0
-			case 13: return set.fds_bits.13 & mask != 0
-			case 14: return set.fds_bits.14 & mask != 0
-			case 15: return set.fds_bits.15 & mask != 0
-			case 16: return set.fds_bits.16 & mask != 0
-			case 17: return set.fds_bits.17 & mask != 0
-			case 18: return set.fds_bits.18 & mask != 0
-			case 19: return set.fds_bits.19 & mask != 0
-			case 20: return set.fds_bits.20 & mask != 0
-			case 21: return set.fds_bits.21 & mask != 0
-			case 22: return set.fds_bits.22 & mask != 0
-			case 23: return set.fds_bits.23 & mask != 0
-			case 24: return set.fds_bits.24 & mask != 0
-			case 25: return set.fds_bits.25 & mask != 0
-			case 26: return set.fds_bits.26 & mask != 0
-			case 27: return set.fds_bits.27 & mask != 0
-			case 28: return set.fds_bits.28 & mask != 0
-			case 29: return set.fds_bits.29 & mask != 0
-			case 30: return set.fds_bits.30 & mask != 0
-			case 31: return set.fds_bits.31 & mask != 0
-			default: return false
-			}
-			
 		}
 	}
 	
 #endif
+
+public extension fd_set
+{
+	@inline(__always)
+	private static func address(for fd: Int32) -> (Int, Int32) {
+		let intOffset = Int(fd) / __fd_set_count
+		let bitOffset = Int(fd) % __fd_set_count
+		let mask = Int32(1 << bitOffset)
+		return (intOffset, mask)
+	}
+	
+	public mutating func zero() {
+		withCArrayAccess { $0.initialize(to: 0, count: __fd_set_count) }
+	}
+	
+	public mutating func set(_ fd: Int32) {
+		let (index, mask) = fd_set.address(for: fd)
+		withCArrayAccess { $0[index] |= mask }
+	}
+	
+	public mutating func clear(_ fd: Int32) {
+		let (index, mask) = fd_set.address(for: fd)
+		withCArrayAccess { $0[index] &= ~mask }
+	}
+	
+	public mutating func isSet(_ fd: Int32) -> Bool {
+		let (index, mask) = fd_set.address(for: fd)
+		return withCArrayAccess { $0[index] & mask != 0 }
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- `fd_set` API is now much nicer and will compile about as close to the C implementation as we can get— especially on release builds, with compiler inlining.
- Socket structure's `readBuffer` now initializes all its bytes to zero, not just the first.
- More idiomatic/concise return expression in `Socket.wait(for:timeout:waitForever:)` (don't build an output array manually, we have `filter(_:)` for that).
- Various non-Linux code to set the `SO_NOSIGPIPE` option has been tucked into a private function now, still containing the compilation conditional. It's a no-op on Linux, and will be inlined by the compiler (since it's private) and the calling code looks much more straightforward.
- BUGFIX: calls to `gai_strerror(_:)` take the result of the `getaddrinfo()` call as a parameter, NOT `errno`.

## Motivation and Context
There's one bug-fix (reports the wrong error from a failed `getaddrinfo()` call), and the `fd_set` changes ought to produce much nicer code— the various `withPointer` calls should be collapsed and inlined to the point where the resulting generated code ought to be pretty close to the equivalent C macros.

## How Has This Been Tested?
All existing tests still pass, so the implementation changes haven't broken anything.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.