### PR TITLE
Fixed the bug in the new fd_set implementation on macOS.

### DIFF
--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -1129,7 +1129,7 @@ public class Socket: SocketReader, SocketWriter {
 
 		// Setup the array of readfds...
 		var readfds = fd_set()
-		FD.ZERO(set: &readfds)
+		readfds.zero()
 
 		var highSocketfd: Int32 = 0
 		for socket in sockets {
@@ -1137,7 +1137,7 @@ public class Socket: SocketReader, SocketWriter {
 			if socket.socketfd > highSocketfd {
 				highSocketfd = socket.socketfd
 			}
-			FD.SET(fd: socket.socketfd, set: &readfds)
+			readfds.set(socket.socketfd)
 		}
 
 		// Issue the select...
@@ -1160,15 +1160,7 @@ public class Socket: SocketReader, SocketWriter {
 		}
 
 		// Build the array of returned sockets...
-		var dataSockets = [Socket]()
-		for socket in sockets {
-
-			if FD.ISSET(fd: socket.socketfd, set: &readfds) {
-				dataSockets.append(socket)
-			}
-		}
-
-		return dataSockets
+		return sockets.filter { readfds.isSet($0.socketfd) }
 	}
 
 	///
@@ -1713,8 +1705,8 @@ public class Socket: SocketReader, SocketWriter {
 					
 					// Set up for the select call...
 					var writefds = fd_set()
-					FD.ZERO(set: &writefds)
-					FD.SET(fd: socketDescriptor!, set: &writefds)
+					writefds.zero()
+					writefds.set(socketDescriptor!)
 					
 					var timer = timeval()
 					
@@ -1742,8 +1734,8 @@ public class Socket: SocketReader, SocketWriter {
 					}
 					
 					// If the socket is writable, we're probably connected, but check anyway to be sure...
-					//	Otherwise, we've timed out waiting to connect.
-					if FD.ISSET(fd: socketDescriptor!, set: &writefds) {
+					//	  Otherwise, we've timed out waiting to connect.
+					if writefds.isSet(socketDescriptor!) {
 						
 						// Check the socket...
 						var result: Int = 0
@@ -3153,12 +3145,12 @@ public class Socket: SocketReader, SocketWriter {
 
 		// Create a read and write file descriptor set for this socket...
 		var readfds = fd_set()
-		FD.ZERO(set: &readfds)
-		FD.SET(fd: self.socketfd, set: &readfds)
+		readfds.zero()
+		readfds.set(self.socketfd)
 
 		var writefds = fd_set()
-		FD.ZERO(set: &writefds)
-		FD.SET(fd: self.socketfd, set: &writefds)
+		writefds.zero()
+		writefds.set(self.socketfd)
 
 		// Do the wait...
 		var count: Int32 = 0
@@ -3204,7 +3196,7 @@ public class Socket: SocketReader, SocketWriter {
 		}
 
 		// Return a tuple containing whether or not this socket is readable and/or writable...
-		return (FD.ISSET(fd: self.socketfd, set: &readfds), FD.ISSET(fd: self.socketfd, set: &writefds))
+		return (readfds.isSet(self.socketfd), writefds.isSet(self.socketfd))
 	}
 
 	///

--- a/Sources/Socket/SocketUtils.swift
+++ b/Sources/Socket/SocketUtils.swift
@@ -66,434 +66,114 @@ extension Socket.Address {
 }
 
 extension Socket.Address {
-	
-	///
-	/// Creates a Socket.Address
-	///
-	/// - Parameters:
-	///		- addressProvider:	Tuple containing pointers to the sockaddr and its length.
-	///
-	///	- Returns:				Newly initialized Socket.Address.
-	///
-	init?(addressProvider: (UnsafeMutablePointer<sockaddr>, UnsafeMutablePointer<socklen_t>) throws -> Void) rethrows {
-		
-		var addressStorage = sockaddr_storage()
-		var addressStorageLength = socklen_t(MemoryLayout.size(ofValue: addressStorage))
-		try withUnsafeMutablePointer(to: &addressStorage) {
-			try $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { addressPointer in
-				try withUnsafeMutablePointer(to: &addressStorageLength) { addressLengthPointer in
-					try addressProvider(addressPointer, addressLengthPointer)
-				}
-			}
-		}
-		
-		switch Int32(addressStorage.ss_family) {
-		case AF_INET:
-			self = withUnsafePointer(to: &addressStorage) {
-				return $0.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
-					return Socket.Address.ipv4($0.pointee)
-				}
-			}
-		case AF_INET6:
-			self = withUnsafePointer(to: &addressStorage) {
-				return $0.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
-					return Socket.Address.ipv6($0.pointee)
-				}
-			}
-		case AF_UNIX:
-			self = withUnsafePointer(to: &addressStorage) {
-				return $0.withMemoryRebound(to: sockaddr_un.self, capacity: 1) {
-					return Socket.Address.unix($0.pointee)
-				}
-			}
-		default:
-			return nil
-		}
-	}
+    
+    ///
+    /// Creates a Socket.Address
+    ///
+    /// - Parameters:
+    ///        - addressProvider:    Tuple containing pointers to the sockaddr and its length.
+    ///
+    ///    - Returns:                Newly initialized Socket.Address.
+    ///
+    init?(addressProvider: (UnsafeMutablePointer<sockaddr>, UnsafeMutablePointer<socklen_t>) throws -> Void) rethrows {
+        
+        var addressStorage = sockaddr_storage()
+        var addressStorageLength = socklen_t(MemoryLayout.size(ofValue: addressStorage))
+        try withUnsafeMutablePointer(to: &addressStorage) {
+            try $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { addressPointer in
+                try withUnsafeMutablePointer(to: &addressStorageLength) { addressLengthPointer in
+                    try addressProvider(addressPointer, addressLengthPointer)
+                }
+            }
+        }
+        
+        switch Int32(addressStorage.ss_family) {
+        case AF_INET:
+            self = withUnsafePointer(to: &addressStorage) {
+                return $0.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+                    return Socket.Address.ipv4($0.pointee)
+                }
+            }
+        case AF_INET6:
+            self = withUnsafePointer(to: &addressStorage) {
+                return $0.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
+                    return Socket.Address.ipv6($0.pointee)
+                }
+            }
+        case AF_UNIX:
+            self = withUnsafePointer(to: &addressStorage) {
+                return $0.withMemoryRebound(to: sockaddr_un.self, capacity: 1) {
+                    return Socket.Address.unix($0.pointee)
+                }
+            }
+        default:
+            return nil
+        }
+    }
 }
 
-#if arch(arm) && os(Linux)
+#if os(Linux)
+    
+    #if arch(arm)
+        let __fd_set_count = 16
+    #else
+        let __fd_set_count = 32
+    #endif
+    
+    extension fd_set
+    {
+        @inline(__always)
+        mutating func withCArrayAccess<T>(block: (UnsafeMutablePointer<Int32>) throws -> T) rethrows -> T {
+            return try withUnsafeMutablePointer(to: &__fds_bits) {
+                try block(UnsafeMutableRawPointer($0).assumingMemoryBound(to: Int32.self))
+            }
+        }
+    }
+    
+#else   // not Linux on ARM
 	
-	public struct FD {
-		
-		/// Replacement for FD_ZERO macro
-		
-		public static func ZERO(set: inout fd_set) {
-			set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-		}
-		
-		
-		/// Replacement for FD_SET macro
-		
-		public static func SET(fd: Int32, set: inout fd_set) {
-			let intOffset = Int32(fd / 32)
-			let bitOffset: Int32 = Int32(fd % 32)
-			let mask: Int32 = 1 << bitOffset
-			switch intOffset {
-			case 0: set.__fds_bits.0 = set.__fds_bits.0 | mask
-			case 1: set.__fds_bits.1 = set.__fds_bits.1 | mask
-			case 2: set.__fds_bits.2 = set.__fds_bits.2 | mask
-			case 3: set.__fds_bits.3 = set.__fds_bits.3 | mask
-			case 4: set.__fds_bits.4 = set.__fds_bits.4 | mask
-			case 5: set.__fds_bits.5 = set.__fds_bits.5 | mask
-			case 6: set.__fds_bits.6 = set.__fds_bits.6 | mask
-			case 7: set.__fds_bits.7 = set.__fds_bits.7 | mask
-			case 8: set.__fds_bits.8 = set.__fds_bits.8 | mask
-			case 9: set.__fds_bits.9 = set.__fds_bits.9 | mask
-			case 10: set.__fds_bits.10 = set.__fds_bits.10 | mask
-			case 11: set.__fds_bits.11 = set.__fds_bits.11 | mask
-			case 12: set.__fds_bits.12 = set.__fds_bits.12 | mask
-			case 13: set.__fds_bits.13 = set.__fds_bits.13 | mask
-			case 14: set.__fds_bits.14 = set.__fds_bits.14 | mask
-			case 15: set.__fds_bits.15 = set.__fds_bits.15 | mask
-			case 16: set.__fds_bits.16 = set.__fds_bits.16 | mask
-			case 17: set.__fds_bits.17 = set.__fds_bits.17 | mask
-			case 18: set.__fds_bits.18 = set.__fds_bits.18 | mask
-			case 19: set.__fds_bits.19 = set.__fds_bits.19 | mask
-			case 20: set.__fds_bits.20 = set.__fds_bits.20 | mask
-			case 21: set.__fds_bits.21 = set.__fds_bits.21 | mask
-			case 22: set.__fds_bits.22 = set.__fds_bits.22 | mask
-			case 23: set.__fds_bits.23 = set.__fds_bits.23 | mask
-			case 24: set.__fds_bits.24 = set.__fds_bits.24 | mask
-			case 25: set.__fds_bits.25 = set.__fds_bits.25 | mask
-			case 26: set.__fds_bits.26 = set.__fds_bits.26 | mask
-			case 27: set.__fds_bits.27 = set.__fds_bits.27 | mask
-			case 28: set.__fds_bits.28 = set.__fds_bits.28 | mask
-			case 29: set.__fds_bits.29 = set.__fds_bits.29 | mask
-			case 30: set.__fds_bits.20 = set.__fds_bits.30 | mask
-			case 31: set.__fds_bits.31 = set.__fds_bits.31 | mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_CLR macro
-		
-		public static func CLR(fd: Int32, set: inout fd_set) {
-			let intOffset = Int32(fd / 32)
-			let bitOffset: Int32 = Int32(fd % 32)
-			let mask: Int32 = ~(1 << bitOffset)
-			switch intOffset {
-			case 0: set.__fds_bits.0 = set.__fds_bits.0 & mask
-			case 1: set.__fds_bits.1 = set.__fds_bits.1 & mask
-			case 2: set.__fds_bits.2 = set.__fds_bits.2 & mask
-			case 3: set.__fds_bits.3 = set.__fds_bits.3 & mask
-			case 4: set.__fds_bits.4 = set.__fds_bits.4 & mask
-			case 5: set.__fds_bits.5 = set.__fds_bits.5 & mask
-			case 6: set.__fds_bits.6 = set.__fds_bits.6 & mask
-			case 7: set.__fds_bits.7 = set.__fds_bits.7 & mask
-			case 8: set.__fds_bits.8 = set.__fds_bits.8 & mask
-			case 9: set.__fds_bits.9 = set.__fds_bits.9 & mask
-			case 10: set.__fds_bits.10 = set.__fds_bits.10 & mask
-			case 11: set.__fds_bits.11 = set.__fds_bits.11 & mask
-			case 12: set.__fds_bits.12 = set.__fds_bits.12 & mask
-			case 13: set.__fds_bits.13 = set.__fds_bits.13 & mask
-			case 14: set.__fds_bits.14 = set.__fds_bits.14 & mask
-			case 15: set.__fds_bits.15 = set.__fds_bits.15 & mask
-			case 16: set.__fds_bits.16 = set.__fds_bits.16 & mask
-			case 17: set.__fds_bits.17 = set.__fds_bits.17 & mask
-			case 18: set.__fds_bits.18 = set.__fds_bits.18 & mask
-			case 19: set.__fds_bits.19 = set.__fds_bits.19 & mask
-			case 20: set.__fds_bits.20 = set.__fds_bits.20 & mask
-			case 21: set.__fds_bits.21 = set.__fds_bits.21 & mask
-			case 22: set.__fds_bits.22 = set.__fds_bits.22 & mask
-			case 23: set.__fds_bits.23 = set.__fds_bits.23 & mask
-			case 24: set.__fds_bits.24 = set.__fds_bits.24 & mask
-			case 25: set.__fds_bits.25 = set.__fds_bits.25 & mask
-			case 26: set.__fds_bits.26 = set.__fds_bits.26 & mask
-			case 27: set.__fds_bits.27 = set.__fds_bits.27 & mask
-			case 28: set.__fds_bits.28 = set.__fds_bits.28 & mask
-			case 29: set.__fds_bits.29 = set.__fds_bits.29 & mask
-			case 30: set.__fds_bits.20 = set.__fds_bits.30 & mask
-			case 31: set.__fds_bits.31 = set.__fds_bits.31 & mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_ISSET macro
-		
-		public static func ISSET(fd: Int32, set: inout fd_set) -> Bool {
-			let intOffset = Int32(fd / 32)
-			let bitOffset = Int32(fd % 32)
-			let mask: Int32 = 1 << bitOffset
-			switch intOffset {
-			case 0: return set.__fds_bits.0 & mask != 0
-			case 1: return set.__fds_bits.1 & mask != 0
-			case 2: return set.__fds_bits.2 & mask != 0
-			case 3: return set.__fds_bits.3 & mask != 0
-			case 4: return set.__fds_bits.4 & mask != 0
-			case 5: return set.__fds_bits.5 & mask != 0
-			case 6: return set.__fds_bits.6 & mask != 0
-			case 7: return set.__fds_bits.7 & mask != 0
-			case 8: return set.__fds_bits.8 & mask != 0
-			case 9: return set.__fds_bits.9 & mask != 0
-			case 10: return set.__fds_bits.10 & mask != 0
-			case 11: return set.__fds_bits.11 & mask != 0
-			case 12: return set.__fds_bits.12 & mask != 0
-			case 13: return set.__fds_bits.13 & mask != 0
-			case 14: return set.__fds_bits.14 & mask != 0
-			case 15: return set.__fds_bits.15 & mask != 0
-			case 16: return set.__fds_bits.16 & mask != 0
-			case 17: return set.__fds_bits.17 & mask != 0
-			case 18: return set.__fds_bits.18 & mask != 0
-			case 19: return set.__fds_bits.19 & mask != 0
-			case 20: return set.__fds_bits.20 & mask != 0
-			case 21: return set.__fds_bits.21 & mask != 0
-			case 22: return set.__fds_bits.22 & mask != 0
-			case 23: return set.__fds_bits.23 & mask != 0
-			case 24: return set.__fds_bits.24 & mask != 0
-			case 25: return set.__fds_bits.25 & mask != 0
-			case 26: return set.__fds_bits.26 & mask != 0
-			case 27: return set.__fds_bits.27 & mask != 0
-			case 28: return set.__fds_bits.28 & mask != 0
-			case 29: return set.__fds_bits.29 & mask != 0
-			case 30: return set.__fds_bits.30 & mask != 0
-			case 31: return set.__fds_bits.31 & mask != 0
-			default: return false
-			}
-			
-		}
-	}
-	
-#elseif os(Linux)
-	
-	public struct FD {
-		
-		/// Replacement for FD_ZERO macro
-		
-		public static func ZERO(set: inout fd_set) {
-			set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-		}
-		
-		
-		/// Replacement for FD_SET macro
-		
-		public static func SET(fd: Int32, set: inout fd_set) {
-			let intOffset = Int(fd / 16)
-			let bitOffset: Int = Int(fd % 16)
-			let mask: Int = 1 << bitOffset
-			switch intOffset {
-			case 0: set.__fds_bits.0 = set.__fds_bits.0 | mask
-			case 1: set.__fds_bits.1 = set.__fds_bits.1 | mask
-			case 2: set.__fds_bits.2 = set.__fds_bits.2 | mask
-			case 3: set.__fds_bits.3 = set.__fds_bits.3 | mask
-			case 4: set.__fds_bits.4 = set.__fds_bits.4 | mask
-			case 5: set.__fds_bits.5 = set.__fds_bits.5 | mask
-			case 6: set.__fds_bits.6 = set.__fds_bits.6 | mask
-			case 7: set.__fds_bits.7 = set.__fds_bits.7 | mask
-			case 8: set.__fds_bits.8 = set.__fds_bits.8 | mask
-			case 9: set.__fds_bits.9 = set.__fds_bits.9 | mask
-			case 10: set.__fds_bits.10 = set.__fds_bits.10 | mask
-			case 11: set.__fds_bits.11 = set.__fds_bits.11 | mask
-			case 12: set.__fds_bits.12 = set.__fds_bits.12 | mask
-			case 13: set.__fds_bits.13 = set.__fds_bits.13 | mask
-			case 14: set.__fds_bits.14 = set.__fds_bits.14 | mask
-			case 15: set.__fds_bits.15 = set.__fds_bits.15 | mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_CLR macro
-		
-		public static func CLR(fd: Int32, set: inout fd_set) {
-			let intOffset = Int(fd / 16)
-			let bitOffset: Int = Int(fd % 16)
-			let mask: Int = ~(1 << bitOffset)
-			switch intOffset {
-			case 0: set.__fds_bits.0 = set.__fds_bits.0 & mask
-			case 1: set.__fds_bits.1 = set.__fds_bits.1 & mask
-			case 2: set.__fds_bits.2 = set.__fds_bits.2 & mask
-			case 3: set.__fds_bits.3 = set.__fds_bits.3 & mask
-			case 4: set.__fds_bits.4 = set.__fds_bits.4 & mask
-			case 5: set.__fds_bits.5 = set.__fds_bits.5 & mask
-			case 6: set.__fds_bits.6 = set.__fds_bits.6 & mask
-			case 7: set.__fds_bits.7 = set.__fds_bits.7 & mask
-			case 8: set.__fds_bits.8 = set.__fds_bits.8 & mask
-			case 9: set.__fds_bits.9 = set.__fds_bits.9 & mask
-			case 10: set.__fds_bits.10 = set.__fds_bits.10 & mask
-			case 11: set.__fds_bits.11 = set.__fds_bits.11 & mask
-			case 12: set.__fds_bits.12 = set.__fds_bits.12 & mask
-			case 13: set.__fds_bits.13 = set.__fds_bits.13 & mask
-			case 14: set.__fds_bits.14 = set.__fds_bits.14 & mask
-			case 15: set.__fds_bits.15 = set.__fds_bits.15 & mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_ISSET macro
-		
-		public static func ISSET(fd: Int32, set: inout fd_set) -> Bool {
-			let intOffset = Int(fd / 16)
-			let bitOffset = Int(fd % 16)
-			let mask: Int = 1 << bitOffset
-			switch intOffset {
-			case 0: return set.__fds_bits.0 & mask != 0
-			case 1: return set.__fds_bits.1 & mask != 0
-			case 2: return set.__fds_bits.2 & mask != 0
-			case 3: return set.__fds_bits.3 & mask != 0
-			case 4: return set.__fds_bits.4 & mask != 0
-			case 5: return set.__fds_bits.5 & mask != 0
-			case 6: return set.__fds_bits.6 & mask != 0
-			case 7: return set.__fds_bits.7 & mask != 0
-			case 8: return set.__fds_bits.8 & mask != 0
-			case 9: return set.__fds_bits.9 & mask != 0
-			case 10: return set.__fds_bits.10 & mask != 0
-			case 11: return set.__fds_bits.11 & mask != 0
-			case 12: return set.__fds_bits.12 & mask != 0
-			case 13: return set.__fds_bits.13 & mask != 0
-			case 14: return set.__fds_bits.14 & mask != 0
-			case 15: return set.__fds_bits.15 & mask != 0
-			default: return false
-			}
-		}
-	}
-	
-#else
-	
-	public struct FD {
-		
-		/// Replacement for FD_ZERO macro
-		
-		public static func ZERO(set: inout fd_set) {
-			set.fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-		}
-		
-		
-		/// Replacement for FD_SET macro
-		
-		public static func SET(fd: Int32, set: inout fd_set) {
-			let intOffset = Int32(fd / 32)
-			let bitOffset = fd % 32
-			let mask: Int32 = 1 << bitOffset
-			switch intOffset {
-			case 0: set.fds_bits.0 = set.fds_bits.0 | mask
-			case 1: set.fds_bits.1 = set.fds_bits.1 | mask
-			case 2: set.fds_bits.2 = set.fds_bits.2 | mask
-			case 3: set.fds_bits.3 = set.fds_bits.3 | mask
-			case 4: set.fds_bits.4 = set.fds_bits.4 | mask
-			case 5: set.fds_bits.5 = set.fds_bits.5 | mask
-			case 6: set.fds_bits.6 = set.fds_bits.6 | mask
-			case 7: set.fds_bits.7 = set.fds_bits.7 | mask
-			case 8: set.fds_bits.8 = set.fds_bits.8 | mask
-			case 9: set.fds_bits.9 = set.fds_bits.9 | mask
-			case 10: set.fds_bits.10 = set.fds_bits.10 | mask
-			case 11: set.fds_bits.11 = set.fds_bits.11 | mask
-			case 12: set.fds_bits.12 = set.fds_bits.12 | mask
-			case 13: set.fds_bits.13 = set.fds_bits.13 | mask
-			case 14: set.fds_bits.14 = set.fds_bits.14 | mask
-			case 15: set.fds_bits.15 = set.fds_bits.15 | mask
-			case 16: set.fds_bits.16 = set.fds_bits.16 | mask
-			case 17: set.fds_bits.17 = set.fds_bits.17 | mask
-			case 18: set.fds_bits.18 = set.fds_bits.18 | mask
-			case 19: set.fds_bits.19 = set.fds_bits.19 | mask
-			case 20: set.fds_bits.20 = set.fds_bits.20 | mask
-			case 21: set.fds_bits.21 = set.fds_bits.21 | mask
-			case 22: set.fds_bits.22 = set.fds_bits.22 | mask
-			case 23: set.fds_bits.23 = set.fds_bits.23 | mask
-			case 24: set.fds_bits.24 = set.fds_bits.24 | mask
-			case 25: set.fds_bits.25 = set.fds_bits.25 | mask
-			case 26: set.fds_bits.26 = set.fds_bits.26 | mask
-			case 27: set.fds_bits.27 = set.fds_bits.27 | mask
-			case 28: set.fds_bits.28 = set.fds_bits.28 | mask
-			case 29: set.fds_bits.29 = set.fds_bits.29 | mask
-			case 30: set.fds_bits.30 = set.fds_bits.30 | mask
-			case 31: set.fds_bits.31 = set.fds_bits.31 | mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_CLR macro
-		
-		public static func CLR(fd: Int32, set: inout fd_set) {
-			let intOffset = Int32(fd / 32)
-			let bitOffset = fd % 32
-			let mask: Int32 = ~(1 << bitOffset)
-			switch intOffset {
-			case 0: set.fds_bits.0 = set.fds_bits.0 & mask
-			case 1: set.fds_bits.1 = set.fds_bits.1 & mask
-			case 2: set.fds_bits.2 = set.fds_bits.2 & mask
-			case 3: set.fds_bits.3 = set.fds_bits.3 & mask
-			case 4: set.fds_bits.4 = set.fds_bits.4 & mask
-			case 5: set.fds_bits.5 = set.fds_bits.5 & mask
-			case 6: set.fds_bits.6 = set.fds_bits.6 & mask
-			case 7: set.fds_bits.7 = set.fds_bits.7 & mask
-			case 8: set.fds_bits.8 = set.fds_bits.8 & mask
-			case 9: set.fds_bits.9 = set.fds_bits.9 & mask
-			case 10: set.fds_bits.10 = set.fds_bits.10 & mask
-			case 11: set.fds_bits.11 = set.fds_bits.11 & mask
-			case 12: set.fds_bits.12 = set.fds_bits.12 & mask
-			case 13: set.fds_bits.13 = set.fds_bits.13 & mask
-			case 14: set.fds_bits.14 = set.fds_bits.14 & mask
-			case 15: set.fds_bits.15 = set.fds_bits.15 & mask
-			case 16: set.fds_bits.16 = set.fds_bits.16 & mask
-			case 17: set.fds_bits.17 = set.fds_bits.17 & mask
-			case 18: set.fds_bits.18 = set.fds_bits.18 & mask
-			case 19: set.fds_bits.19 = set.fds_bits.19 & mask
-			case 20: set.fds_bits.20 = set.fds_bits.20 & mask
-			case 21: set.fds_bits.21 = set.fds_bits.21 & mask
-			case 22: set.fds_bits.22 = set.fds_bits.22 & mask
-			case 23: set.fds_bits.23 = set.fds_bits.23 & mask
-			case 24: set.fds_bits.24 = set.fds_bits.24 & mask
-			case 25: set.fds_bits.25 = set.fds_bits.25 & mask
-			case 26: set.fds_bits.26 = set.fds_bits.26 & mask
-			case 27: set.fds_bits.27 = set.fds_bits.27 & mask
-			case 28: set.fds_bits.28 = set.fds_bits.28 & mask
-			case 29: set.fds_bits.29 = set.fds_bits.29 & mask
-			case 30: set.fds_bits.30 = set.fds_bits.30 & mask
-			case 31: set.fds_bits.31 = set.fds_bits.31 & mask
-			default: break
-			}
-		}
-		
-		
-		/// Replacement for FD_ISSET macro
-		
-		public static func ISSET(fd: Int32, set: inout fd_set) -> Bool {
-			let intOffset = Int32(fd / 32)
-			let bitOffset = fd % 32
-			let mask: Int32 = 1 << bitOffset
-			switch intOffset {
-			case 0: return set.fds_bits.0 & mask != 0
-			case 1: return set.fds_bits.1 & mask != 0
-			case 2: return set.fds_bits.2 & mask != 0
-			case 3: return set.fds_bits.3 & mask != 0
-			case 4: return set.fds_bits.4 & mask != 0
-			case 5: return set.fds_bits.5 & mask != 0
-			case 6: return set.fds_bits.6 & mask != 0
-			case 7: return set.fds_bits.7 & mask != 0
-			case 8: return set.fds_bits.8 & mask != 0
-			case 9: return set.fds_bits.9 & mask != 0
-			case 10: return set.fds_bits.10 & mask != 0
-			case 11: return set.fds_bits.11 & mask != 0
-			case 12: return set.fds_bits.12 & mask != 0
-			case 13: return set.fds_bits.13 & mask != 0
-			case 14: return set.fds_bits.14 & mask != 0
-			case 15: return set.fds_bits.15 & mask != 0
-			case 16: return set.fds_bits.16 & mask != 0
-			case 17: return set.fds_bits.17 & mask != 0
-			case 18: return set.fds_bits.18 & mask != 0
-			case 19: return set.fds_bits.19 & mask != 0
-			case 20: return set.fds_bits.20 & mask != 0
-			case 21: return set.fds_bits.21 & mask != 0
-			case 22: return set.fds_bits.22 & mask != 0
-			case 23: return set.fds_bits.23 & mask != 0
-			case 24: return set.fds_bits.24 & mask != 0
-			case 25: return set.fds_bits.25 & mask != 0
-			case 26: return set.fds_bits.26 & mask != 0
-			case 27: return set.fds_bits.27 & mask != 0
-			case 28: return set.fds_bits.28 & mask != 0
-			case 29: return set.fds_bits.29 & mask != 0
-			case 30: return set.fds_bits.30 & mask != 0
-			case 31: return set.fds_bits.31 & mask != 0
-			default: return false
-			}
-			
-		}
-	}
-	
+	// __DARWIN_FD_SETSIZE is number of *bits*, so divide by number bits in each element to get element count
+	// at present this is 1024 / 32 == 32
+    let __fd_set_count = Int(__DARWIN_FD_SETSIZE) / 32
+    
+    extension fd_set
+    {
+        @inline(__always)
+        mutating func withCArrayAccess<T>(block: (UnsafeMutablePointer<Int32>) throws -> T) rethrows -> T {
+            return try withUnsafeMutablePointer(to: &fds_bits) {
+                try block(UnsafeMutableRawPointer($0).assumingMemoryBound(to: Int32.self))
+            }
+        }
+    }
+    
 #endif
 
+public extension fd_set
+{
+    @inline(__always)
+    private static func address(for fd: Int32) -> (Int, Int32) {
+        let intOffset = Int(fd) / __fd_set_count
+        let bitOffset = Int(fd) % __fd_set_count
+        let mask = Int32(1 << bitOffset)
+        return (intOffset, mask)
+    }
+    
+    public mutating func zero() {
+        withCArrayAccess { $0.initialize(to: 0, count: __fd_set_count) }
+    }
+    
+    public mutating func set(_ fd: Int32) {
+        let (index, mask) = fd_set.address(for: fd)
+        withCArrayAccess { $0[index] |= mask }
+    }
+    
+    public mutating func clear(_ fd: Int32) {
+        let (index, mask) = fd_set.address(for: fd)
+        withCArrayAccess { $0[index] &= ~mask }
+    }
+    
+    public mutating func isSet(_ fd: Int32) -> Bool {
+        let (index, mask) = fd_set.address(for: fd)
+        return withCArrayAccess { $0[index] & mask != 0 }
+    }
+}


### PR DESCRIPTION
The implementation from the prior pull request now runs happily without corrupting the stack.

## Description
I'm calculating the size of the Darwin fd_set correctly now— dividing the `__DARWIN_FD_SET_SIZE` bit-count by the number of *bits* in an `Int32` rather than the stride size (number of *bytes*).

## Motivation and Context
This fixes the crash in #110 properly while keeping the optimized fd_set implementation.

## How Has This Been Tested?
The updated unit tests which caught the original error now pass, and I've verified personally that the implementation does the right thing now, setting the expected bits in the bitfield.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.