### PR TITLE
Fixed a bit-addressing error in fd_set implementation.

### DIFF
--- a/Sources/Socket/SocketUtils.swift
+++ b/Sources/Socket/SocketUtils.swift
@@ -154,7 +154,7 @@ public extension fd_set {
     private static func address(for fd: Int32) -> (Int, Int32) {
         let intOffset = Int(fd) / __fd_set_count
         let bitOffset = Int(fd) % __fd_set_count
-        let mask = Int32(1 << bitOffset)
+        let mask = Int32(bitPattern: UInt32(1 << bitOffset))
         return (intOffset, mask)
     }
 	

--- a/Tests/SocketTests/SocketTests.swift
+++ b/Tests/SocketTests/SocketTests.swift
@@ -1125,6 +1125,18 @@ class SocketTests: XCTestCase {
 		}
 	}
 	
+	func testFDSetBitFields() {
+		var fdSet = fd_set()
+		fdSet.zero()
+		
+		for i: Int32 in 0...128 {
+			fdSet.set(i)
+			XCTAssertTrue(fdSet.isSet(i))
+			fdSet.clear(i)
+			XCTAssertFalse(fdSet.isSet(i))
+		}
+	}
+	
 	func testReadWrite() {
 		
 		let hostname = "127.0.0.1"

--- a/Tests/SocketTests/SocketTests.swift
+++ b/Tests/SocketTests/SocketTests.swift
@@ -1519,6 +1519,7 @@ class SocketTests: XCTestCase {
 		("testSetWriteTimeout", testSetWriteTimeout),
 		("testIsReadableWritableFail", testIsReadableWritableFail),
 		("testIsReadableWritable", testIsReadableWritable),
+		("testFDSetBitFields", testFDSetBitFields),
 		("testReadWrite", testReadWrite),
 		("testTruncateTCP", testTruncateTCP),
 		("testReadWriteUDP", testReadWriteUDP),


### PR DESCRIPTION
## Description
- Now uses an unsigned type to perform the bit-shift operation and then casts to signed type using `init(bitPattern:)`.
- Added a unit test case which ensures fd values from zero to (arbitrarily) 128 can all be inserted and removed from the` fd_set`.

## Motivation and Context
This fixes the `fd_set` component of issue #120.

## How Has This Been Tested?
Unit test added to verify that the new code works (and which caused the old code to crash in the same manner as described in issue #120).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.