### PR TITLE
Endian fix

### DIFF
--- a/Sources/Socket/SocketUtils.swift
+++ b/Sources/Socket/SocketUtils.swift
@@ -153,11 +153,13 @@ public extension fd_set {
     @inline(__always)
     private static func address(for fd: Int32) -> (Int, Int32) {
         var intOffset = Int(fd) / __fd_set_count
-		if (intOffset % 2 == 0) {
-			intOffset += 1
-		} else {
-			intOffset -= 1
-		}
+		#if arch(s390x)
+		    if (intOffset % 2 == 0) {
+			    intOffset += 1
+		    } else {
+			    intOffset -= 1
+		    }
+        #endif
         let bitOffset = Int(fd) % __fd_set_count
         let mask = Int32(bitPattern: UInt32(1 << bitOffset))
         return (intOffset, mask)

--- a/Sources/Socket/SocketUtils.swift
+++ b/Sources/Socket/SocketUtils.swift
@@ -154,7 +154,7 @@ public extension fd_set {
     private static func address(for fd: Int32) -> (Int, Int32) {
         var intOffset = Int(fd) / __fd_set_count
 		#if _endian(big)
-		    if (intOffset % 2 == 0) {
+		    if intOffset % 2 == 0 {
 			    intOffset += 1
 		    } else {
 			    intOffset -= 1

--- a/Sources/Socket/SocketUtils.swift
+++ b/Sources/Socket/SocketUtils.swift
@@ -152,7 +152,12 @@ public extension fd_set {
 
     @inline(__always)
     private static func address(for fd: Int32) -> (Int, Int32) {
-        let intOffset = Int(fd) / __fd_set_count
+        var intOffset = Int(fd) / __fd_set_count
+		if (intOffset % 2 == 0) {
+			intOffset += 1
+		} else {
+			intOffset -= 1
+		}
         let bitOffset = Int(fd) % __fd_set_count
         let mask = Int32(bitPattern: UInt32(1 << bitOffset))
         return (intOffset, mask)

--- a/Sources/Socket/SocketUtils.swift
+++ b/Sources/Socket/SocketUtils.swift
@@ -153,7 +153,7 @@ public extension fd_set {
     @inline(__always)
     private static func address(for fd: Int32) -> (Int, Int32) {
         var intOffset = Int(fd) / __fd_set_count
-		#if arch(s390x)
+		#if _endian(big)
 		    if (intOffset % 2 == 0) {
 			    intOffset += 1
 		    } else {


### PR DESCRIPTION
Fix for big endian machines.

## Description
fd_set is defined as 16 64-bit integers in a 64-bit linux machine. Since this package accesses fd_set per 32 bits, endianess needs to be taken aware to calculate the index.

## Motivation and Context
Now, swift is running on IBM mainframe (https://www.ibm.com/developerworks/downloads/r/toolkitforswift/). This fix is essential for Kitura to run on a big endian machine with SSL.

## How Has This Been Tested?
Ran all of the tests on a s390x machine. Results are as follows. Test failures were reduced from 8 to 6.

```
Compile Swift Module 'Socket' (3 sources)
Linking ./.build/s390x-unknown-linux/debug/SocketPackageTests.xctest
Test Suite 'All tests' started at 2018-04-09 10:32:03.293
Test Suite 'debug.xctest' started at 2018-04-09 10:32:03.294
Test Suite 'SocketTests' started at 2018-04-09 10:32:03.294
Test Case 'SocketTests.testFDSetBitFields' started at 2018-04-09 10:32:03.294
Test Case 'SocketTests.testFDSetBitFields' passed (0.003 seconds)
Test Case 'SocketTests.testSetReadTimeout' started at 2018-04-09 10:32:03.297
Test Case 'SocketTests.testSetReadTimeout' passed (0.292 seconds)
Test Case 'SocketTests.testListenUDP' started at 2018-04-09 10:32:03.589
Test Case 'SocketTests.testListenUDP' passed (1.0 seconds)
Test Case 'SocketTests.testTruncateTCP' started at 2018-04-09 10:32:04.590
Listening on port: 1337

Connected to host: 127.0.0.1:1337
Accepted connection from: 127.0.0.1 on port 53912, Secure? false
	Socket signature: Signature: family: inet, type: stream, protocol: tcp, address: Optional(Socket.Socket.Address.ipv4(__C.sockaddr_in(sin_family: 32512, sin_port: 1, sin_addr: __C.in_addr(s_addr: 0), sin_zero: (0, 2, 5, 57, 0, 0, 0, 0)))), hostname: Optional("127.0.0.1"), port: 1337, path: nil, bound: false, secure: false

Read 34 from socket...
Response:
Hello, type 'QUIT' to end session

Wrote 'Hello from client...' to socket...
Server received from connection at 127.0.0.1:53912: Hello from client... 
Read 21 from socket...
Response:
Hello from client...

Sent quit to server...
Server received from connection at 127.0.0.1:53912: QUIT 
Test Case 'SocketTests.testTruncateTCP' passed (3.002 seconds)
Test Case 'SocketTests.testReadWriteUDP' started at 2018-04-09 10:32:07.592
Received 14 bytes from 127.0.0.1:38401: Hello from UDP

Sending response
Received from 127.0.0.1:1337: Server response: 
Hello from UDP


Received 11 bytes from 127.0.0.1:38401: Hello again

Sending response
Received from 127.0.0.1:1337: Server re

Sending quit to server...
Received 4 bytes from 127.0.0.1:38401: QUIT

Sending response
Test Case 'SocketTests.testReadWriteUDP' passed (3.001 seconds)
Test Case 'SocketTests.testCreateUnix' started at 2018-04-09 10:32:10.593
Test Case 'SocketTests.testCreateUnix' passed (0.0 seconds)
Test Case 'SocketTests.testConnectToPath' started at 2018-04-09 10:32:10.593
testConnectToPath Error reported: Error code: -9985(0x-2701), Invalid argument
/home/nakaike/git/BlueSocket/Tests/SocketTests/SocketTests.swift:837: error: SocketTests.testConnectToPath : failed - 
Test Case 'SocketTests.testConnectToPath' failed (0.0 seconds)
Test Case 'SocketTests.testReadWrite' started at 2018-04-09 10:32:10.594
Listening on port: 1337
Accepted connection from: 127.0.0.1 on port 53914, Secure? false

Connected to host: 127.0.0.1:1337
	Socket signature: Signature: family: inet, type: stream, protocol: tcp, address: Optional(Socket.Socket.Address.ipv4(__C.sockaddr_in(sin_family: 32512, sin_port: 1, sin_addr: __C.in_addr(s_addr: 0), sin_zero: (0, 2, 5, 57, 0, 0, 0, 0)))), hostname: Optional("127.0.0.1"), port: 1337, path: nil, bound: false, secure: false

Read 34 from socket...
Response:
Hello, type 'QUIT' to end session

Wrote 'Hello from client...' to socket...
Server received from connection at 127.0.0.1:53914: Hello from client... 
Read 39 from socket...
Response:
Server response: 
Hello from client...

Sent quit to server...
Server received from connection at 127.0.0.1:53914: QUIT 
Test Case 'SocketTests.testReadWrite' passed (3.001 seconds)
Test Case 'SocketTests.testIsReadableWritable' started at 2018-04-09 10:32:13.595
Socket2 is readable: false, writable: true
Test Case 'SocketTests.testIsReadableWritable' passed (0.0 seconds)
Test Case 'SocketTests.testIsReadableWritableFail' started at 2018-04-09 10:32:13.596
testIsReadableWritableFail Error reported: Error code: -9996(0x-270C), Reason: Unavailable
Test Case 'SocketTests.testIsReadableWritableFail' passed (0.0 seconds)
Test Case 'SocketTests.testSetWriteTimeout' started at 2018-04-09 10:32:13.596
Test Case 'SocketTests.testSetWriteTimeout' passed (0.006 seconds)
Test Case 'SocketTests.testConnect' started at 2018-04-09 10:32:13.601
Test Case 'SocketTests.testConnect' passed (0.0 seconds)
Test Case 'SocketTests.testListen' started at 2018-04-09 10:32:13.601
Test Case 'SocketTests.testListen' passed (0.0 seconds)
Test Case 'SocketTests.testConnectToWithTimeout' started at 2018-04-09 10:32:13.601
Test Case 'SocketTests.testConnectToWithTimeout' passed (0.0 seconds)
Test Case 'SocketTests.testHostnameAndPort' started at 2018-04-09 10:32:13.602
/home/nakaike/git/BlueSocket/Tests/SocketTests/SocketTests.swift:910: error: SocketTests.testHostnameAndPort : XCTAssertEqual failed: ("127.0.0.1") is not equal to ("") - 
/home/nakaike/git/BlueSocket/Tests/SocketTests/SocketTests.swift:911: error: SocketTests.testHostnameAndPort : XCTAssertEqual failed: ("1337") is not equal to ("1") - 
Test Case 'SocketTests.testHostnameAndPort' failed (0.0 seconds)
Test Case 'SocketTests.testReadWriteUnix' started at 2018-04-09 10:32:13.602
serverHelper Error reported: Error code: -9985(0x-2701), Invalid argument
/home/nakaike/git/BlueSocket/Tests/SocketTests/SocketTests.swift:202: error: SocketTests.testReadWriteUnix : failed - 
testReadWriteUnix Error reported: Error code: -9988(0x-2704), Invalid argument
/home/nakaike/git/BlueSocket/Tests/SocketTests/SocketTests.swift:1499: error: SocketTests.testReadWriteUnix : failed - 
Test Case 'SocketTests.testReadWriteUnix' failed (2.001 seconds)
Test Case 'SocketTests.testConnectTo' started at 2018-04-09 10:32:15.602
Test Case 'SocketTests.testConnectTo' passed (0.0 seconds)
Test Case 'SocketTests.testBlocking' started at 2018-04-09 10:32:15.603
Test Case 'SocketTests.testBlocking' passed (0.0 seconds)
Test Case 'SocketTests.testListenUnix' started at 2018-04-09 10:32:15.603
testListenUnix Error reported: Error code: -9985(0x-2701), Invalid argument
/home/nakaike/git/BlueSocket/Tests/SocketTests/SocketTests.swift:536: error: SocketTests.testListenUnix : failed - 
Test Case 'SocketTests.testListenUnix' failed (0.0 seconds)
Test Case 'SocketTests.testConnectPort0' started at 2018-04-09 10:32:15.603
Listener signature: Optional("Signature: family: inet, type: stream, protocol: tcp, address: Optional(Socket.Socket.Address.ipv4(__C.sockaddr_in(sin_family: 2, sin_port: 43591, sin_addr: __C.in_addr(s_addr: 0), sin_zero: (0, 0, 0, 0, 0, 0, 0, 0)))), hostname: Optional(\"0.0.0.0\"), port: 43591, path: nil, bound: true, secure: false")
Connect signature: Optional("Signature: family: inet, type: stream, protocol: tcp, address: Optional(Socket.Socket.Address.ipv4(__C.sockaddr_in(sin_family: 0, sin_port: 0, sin_addr: __C.in_addr(s_addr: 0), sin_zero: (0, 2, 170, 71, 0, 0, 0, 0)))), hostname: Optional(\"0.0.0.0\"), port: 43591, path: nil, bound: false, secure: false")
Test Case 'SocketTests.testConnectPort0' passed (0.0 seconds)
Test Case 'SocketTests.testDefaultCreate' started at 2018-04-09 10:32:15.603
Test Case 'SocketTests.testDefaultCreate' passed (0.0 seconds)
Test Case 'SocketTests.testCreateUDP' started at 2018-04-09 10:32:15.603
Test Case 'SocketTests.testCreateUDP' passed (0.0 seconds)
Test Case 'SocketTests.testListenPort0UDP' started at 2018-04-09 10:32:15.603
Listening port: 54573
Test Case 'SocketTests.testListenPort0UDP' passed (1.001 seconds)
Test Case 'SocketTests.testCreateIPV6' started at 2018-04-09 10:32:16.604
Test Case 'SocketTests.testCreateIPV6' passed (0.0 seconds)
Test Case 'SocketTests.testListenPort0' started at 2018-04-09 10:32:16.605
Listening port: 36586
Test Case 'SocketTests.testListenPort0' passed (0.0 seconds)
Test Suite 'SocketTests' failed at 2018-04-09 10:32:16.605
	 Executed 25 tests, with 6 failures (0 unexpected) in 13.31 (13.31) seconds
Test Suite 'debug.xctest' failed at 2018-04-09 10:32:16.605
	 Executed 25 tests, with 6 failures (0 unexpected) in 13.31 (13.31) seconds
Test Suite 'All tests' failed at 2018-04-09 10:32:16.605
	 Executed 25 tests, with 6 failures (0 unexpected) in 13.31 (13.31) seconds
```

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
