### PR TITLE
Make `connect()` work for UDP sockets as well

### DIFF
--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -1639,7 +1639,7 @@ public class Socket: SocketReader, SocketWriter {
 		}
 
 		// Create the hints for our search...
-		let socketType: SocketType = .stream
+		let socketType: SocketType = signature?.socketType ?? .stream
 		#if os(Linux)
 			var hints = addrinfo(
 				ai_flags: AI_PASSIVE,


### PR DESCRIPTION
If I'm not mistaken, in order to receive an UDP datagram from a specific other party, one currently needs to listen on a specific port and filter out messages from unwanted senders. E.g.

```
let socket = try Socket.create(family: .inet, type: .datagram, proto: .udp)
var message = Data()
repeat {
    let (size, sender) = try socket.listen(forMessage: &message, on: 8053, maxBacklogSize: 0)
} while sender != bob
```

However using `connect (2)` this should be as simple as:

```
let socket = try Socket.create(family: .inet, type: .datagram, proto: .udp)
try socket.connect(to: bob.ip, port: bob.port)
var message = Data()
try socket.readDatagram(into: &message)
```

## How Has This Been Tested?
Limited tests on macOS; stepping through debugger to find the problem when trying to connect to UDP sockets.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

Are any of the above required for this PR?