### PR TITLE
perf: improve read throughput in debug mode

### DIFF
--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -3453,7 +3453,7 @@ public class Socket: SocketReader, SocketWriter {
 	///
 	private func readDataIntoStorage() throws -> Int {
 
-		// Clear the buffer...
+		// Initialize the buffer...
 		#if swift(>=4.1)
 			self.readBuffer.initialize(to: 0x0)
 		#else
@@ -3569,7 +3569,7 @@ public class Socket: SocketReader, SocketWriter {
 	///
 	private func readDatagramIntoStorage() throws -> (bytesRead: Int, fromAddress: Address?) {
 
-		// Clear the buffer...
+		// Initialize the buffer...
 		#if swift(>=4.1)
 			self.readBuffer.initialize(to: 0x0)
 		#else

--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -828,7 +828,7 @@ public class Socket: SocketReader, SocketWriter {
 					readBuffer.deinitialize(count: readBufferSize)
 					readBuffer.deallocate()
 					readBuffer = UnsafeMutablePointer<CChar>.allocate(capacity: readBufferSize)
-					readBuffer.initialize(repeating: 0, count: readBufferSize)
+					readBuffer.initialize(to: 0)
 				#else
 					readBuffer.deinitialize()
 					readBuffer.deallocate(capacity: oldValue)
@@ -1239,7 +1239,7 @@ public class Socket: SocketReader, SocketWriter {
 
 		// Initialize the read buffer...
 		#if swift(>=4.1)
-			self.readBuffer.initialize(repeating: 0, count: readBufferSize)
+			self.readBuffer.initialize(to: 0)
 		#else
 			self.readBuffer.initialize(to: 0, count: readBufferSize)
 		#endif
@@ -1288,7 +1288,7 @@ public class Socket: SocketReader, SocketWriter {
 		self.isConnected = true
 		self.isListening = false
 		#if swift(>=4.1)
-			self.readBuffer.initialize(repeating: 0, count: readBufferSize)
+			self.readBuffer.initialize(to: 0)
 		#else
 			self.readBuffer.initialize(to: 0, count: readBufferSize)
 		#endif
@@ -3455,7 +3455,7 @@ public class Socket: SocketReader, SocketWriter {
 
 		// Clear the buffer...
 		#if swift(>=4.1)
-			self.readBuffer.initialize(repeating: 0x0, count: readBufferSize)
+			self.readBuffer.initialize(to: 0x0)
 		#else
 			self.readBuffer.initialize(to: 0x0, count: readBufferSize)
 		#endif
@@ -3571,7 +3571,7 @@ public class Socket: SocketReader, SocketWriter {
 
 		// Clear the buffer...
 		#if swift(>=4.1)
-			self.readBuffer.initialize(repeating: 0x0, count: readBufferSize)
+			self.readBuffer.initialize(to: 0x0)
 		#else
 			self.readBuffer.initialize(to: 0x0, count: readBufferSize)
 		#endif


### PR DESCRIPTION
Only initialize the first byte of `readBuffer` instead of zeroing the whole buffer.

## Description

Currently, before we read from the socket we call `readBuffer.initialize(repeating: 0, count: readBufferSize)` which zeroes out the memory in `readBuffer`.

I don't believe this is necessary because the buffer is about to be overwritten with bytes from the wire anyway, and once that has happened we then copy the read bytes into `readStorage`.

This PR changes the code so we use `initialize(to:)` instead, so only the first byte is zeroed. We do have to call `initialize()` (we can't just remove it completely) but it's cheaper to only initialize one byte.

## Motivation and Context

I've recently been analysing Kitura performance, and the cost of `Socket.readDataIntoStorage()` is significant in debug mode. Most of this is zeroing out the buffer.

## How Has This Been Tested?

Performance testing Kitura built in debug mode using simple HelloWorld app. Load was driven via `wrk` with 128 concurrent connections across 4 cores.

Ubuntu 14.04:

```
               | Throughput (req/s)      | CPU (%) | Mem (kb)     | Latency (ms)                   | good
Implementation | Average    | Max        | Average | Avg peak RSS | Average  | 99%      | Max      | iters
---------------|------------|------------|---------|--------------|----------|----------|----------|-------
      Baseline |    23189.2 |    24327.4 |    96.8 |        25727 |      5.7 |     19.4 |    216.9 |    20
           New |    25400.1 |    26660.6 |    98.2 |        25867 |      5.0 |     12.6 |    205.1 |    20
```

9.5% increase in throughput.

Ubuntu 16.04:

```
               | Throughput (req/s)      | CPU (%) | Mem (kb)     | Latency (ms)                   | good
Implementation | Average    | Max        | Average | Avg peak RSS | Average  | 99%      | Max      | iters
---------------|------------|------------|---------|--------------|----------|----------|----------|-------
      Baseline |    27412.0 |    27894.6 |    95.4 |        27771 |      5.0 |     18.8 |    205.5 |    20
           New |    30996.2 |    32167.2 |    98.5 |        27794 |      4.1 |     10.3 |    201.4 |    20
```

13% increase in throughput.

There is no measurable difference in release mode unfortunately, but this improvement is still worth making because not everyone knows/remembers to compile in release mode. Plus, fixing this low-hanging fruit may help expose other performance bottlenecks we can fix.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
