### PR TITLE
Improve using Signature to connect socket

### DIFF
--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -3559,9 +3559,7 @@ public class Socket: SocketReader, SocketWriter {
 
 				// - Could be an error, but if errno is EAGAIN or EWOULDBLOCK (if a non-blocking socket),
 				//	it means there was NO data to read...
-				case EAGAIN:
-					fallthrough
-				case EWOULDBLOCK:
+				case EWOULDBLOCK, EAGAIN:
 					return self.readStorage.length
 
 				case ECONNRESET:

--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -3008,7 +3008,7 @@ public class Socket: SocketReader, SocketWriter {
 
 				// - Handle a connection reset by peer (ECONNRESET) and throw a different exception...
 				if errno == ECONNRESET {
-
+					self.remoteConnectionClosed = true
 					throw Error(code: Socket.SOCKET_ERR_CONNECTION_RESET, reason: self.lastError())
 				}
 
@@ -3139,7 +3139,7 @@ public class Socket: SocketReader, SocketWriter {
 					
 					// - Handle a connection reset by peer (ECONNRESET) and throw a different exception...
 					if errno == ECONNRESET {
-						
+						self.remoteConnectionClosed = true
 						throw Error(code: Socket.SOCKET_ERR_CONNECTION_RESET, reason: self.lastError())
 					}
 					
@@ -3566,6 +3566,7 @@ public class Socket: SocketReader, SocketWriter {
 
 				case ECONNRESET:
 					// - Handle a connection reset by peer (ECONNRESET) and throw a different exception...
+					self.remoteConnectionClosed = true
 					throw Error(code: Socket.SOCKET_ERR_CONNECTION_RESET, reason: self.lastError())
 
 				default:
@@ -3635,7 +3636,7 @@ public class Socket: SocketReader, SocketWriter {
 					
 					// - Handle a connection reset by peer (ECONNRESET) and throw a different exception...
 					if errno == ECONNRESET {
-						
+						self.remoteConnectionClosed = true
 						throw Error(code: Socket.SOCKET_ERR_CONNECTION_RESET, reason: self.lastError())
 					}
 					

--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -467,10 +467,12 @@ public class Socket: SocketReader, SocketWriter {
 		///		- socketType:		The type of socket to create.
 		///		- proto:			The protocool to use for the socket.
 		/// 	- address:			Address info for the socket.
+		/// 	- hostname:			Hostname for this signature.
+		/// 	- port:				Port for this signature.
 		///
 		/// - Returns: New Signature instance
 		///
-		public init?(socketType: SocketType, proto: SocketProtocol, address: Address) throws {
+		public init?(socketType: SocketType, proto: SocketProtocol, address: Address, hostname: String?, port: Int32?) throws {
 			
 			// Validate the parameters...
 			if socketType == .stream {
@@ -491,6 +493,10 @@ public class Socket: SocketReader, SocketWriter {
 			self.proto = proto
 			
 			self.address = address
+			self.hostname = hostname
+			if let port = port {
+				self.port = port
+			}
 		}
 
 		///
@@ -2011,83 +2017,77 @@ public class Socket: SocketReader, SocketWriter {
 			try self.connect(to: path)
 			return
 		}
-
-		if signature.hostname == nil || signature.port == Socket.SOCKET_INVALID_PORT {
-
-			guard let _ = signature.address else {
-
-				throw Error(code: Socket.SOCKET_ERR_MISSING_CONNECTION_DATA, reason: "Unable to access connection data.")
+		
+		if let address = signature.address {
+			// Tell the delegate to initialize as a client...
+			do {
+				
+				try self.delegate?.initialize(asServer: false)
+				
+			} catch let error {
+				
+				guard let sslError = error as? SSLError else {
+					
+					throw error
+				}
+				
+				throw Error(with: sslError)
 			}
-
-		} else {
-
-			// Otherwise, make sure we've got a hostname and port...
-			guard let hostname = signature.hostname,
-				signature.port != Socket.SOCKET_INVALID_PORT else {
-
-					throw Error(code: Socket.SOCKET_ERR_MISSING_CONNECTION_DATA, reason: "Unable to access hostname and port.")
+			
+			// Now, do the connection using the supplied address...
+			let rc = address.withSockAddrPointer { sockaddr, length -> Int32 in
+				#if os(Linux)
+				return Glibc.connect(self.socketfd, sockaddr, length)
+				#else
+				return Darwin.connect(self.socketfd, sockaddr, length)
+				#endif
 			}
+			
+			if rc < 0 {
+				
+				throw Error(code: Socket.SOCKET_ERR_CONNECT_FAILED, reason: self.lastError())
+			}
+			
+			if signature.hostname != nil, signature.port != Socket.SOCKET_INVALID_PORT {
+				self.signature = signature
+				self.isConnected = true
+			} else if let (hostname, port) = Socket.hostnameAndPort(from: signature.address!) {
 
+				var sig = signature
+				sig.hostname = hostname
+				sig.port = Int32(port)
+				self.signature = sig
+				self.isConnected = true
+			}
+			
+			// Let the delegate do post connect handling and verification...
+			do {
+				
+				if self.delegate != nil {
+					try self.delegate?.onConnect(socket: self)
+					self.signature?.isSecure = true
+				}
+				
+			} catch let error {
+				
+				guard let sslError = error as? SSLError else {
+					
+					throw error
+				}
+				
+				throw Error(with: sslError)
+			}
+			
+			return
+		}
+		
+		if let hostname = signature.hostname, signature.port != Socket.SOCKET_INVALID_PORT {
 			// Connect using hostname and port....
 			try self.connect(to: hostname, port: signature.port)
 			return
 		}
-
-		// Tell the delegate to initialize as a client...
-		do {
-
-			try self.delegate?.initialize(asServer: false)
-
-		} catch let error {
-
-			guard let sslError = error as? SSLError else {
-
-				throw error
-			}
-
-			throw Error(with: sslError)
-		}
-
-		// Now, do the connection using the supplied address...
-		let rc = signature.address!.withSockAddrPointer { sockaddr, length -> Int32 in
-			#if os(Linux)
-				return Glibc.connect(self.socketfd, sockaddr, length)
-			#else
-				return Darwin.connect(self.socketfd, sockaddr, length)
-			#endif
-		}
 		
-		if rc < 0 {
-
-			throw Error(code: Socket.SOCKET_ERR_CONNECT_FAILED, reason: self.lastError())
-		}
-
-		if let (hostname, port) = Socket.hostnameAndPort(from: signature.address!) {
-
-			var sig = signature
-			sig.hostname = hostname
-			sig.port = Int32(port)
-			self.signature = sig
-			self.isConnected = true
-		}
-
-		// Let the delegate do post connect handling and verification...
-		do {
-
-			if self.delegate != nil {
-				try self.delegate?.onConnect(socket: self)
-				self.signature?.isSecure = true
-			}
-
-		} catch let error {
-
-			guard let sslError = error as? SSLError else {
-
-				throw error
-			}
-
-			throw Error(with: sslError)
-		}
+		throw Error(code: Socket.SOCKET_ERR_MISSING_CONNECTION_DATA, reason: "Unable to access connection data.")
 	}
 
 	// MARK: -- Listen

--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -459,6 +459,39 @@ public class Socket: SocketReader, SocketWriter {
 			self.address = address
 
 		}
+		
+		///
+		/// Create a socket signature
+		///
+		///	- Parameters:
+		///		- socketType:		The type of socket to create.
+		///		- proto:			The protocool to use for the socket.
+		/// 	- address:			Address info for the socket.
+		///
+		/// - Returns: New Signature instance
+		///
+		public init?(socketType: SocketType, proto: SocketProtocol, address: Address) throws {
+			
+			// Validate the parameters...
+			if socketType == .stream {
+				guard proto == .tcp || proto == .unix else {
+					
+					throw Error(code: Socket.SOCKET_ERR_BAD_SIGNATURE_PARAMETERS, reason: "Stream socket must use either .tcp or .unix for the protocol.")
+				}
+			}
+			if socketType == .datagram {
+				guard proto == .udp || proto == .unix else {
+					
+					throw Error(code: Socket.SOCKET_ERR_BAD_SIGNATURE_PARAMETERS, reason: "Datagram socket must use .udp or .unix for the protocol.")
+				}
+			}
+			
+			self.protocolFamily = address.family
+			self.socketType = socketType
+			self.proto = proto
+			
+			self.address = address
+		}
 
 		///
 		/// Create a socket signature


### PR DESCRIPTION
Allows to create a signature from an Address object and still have a hostname.

## Description
The first commit just adds creation of Socket with an Address using the enums for socketType and protocol

The second one rearranges `func connect(using` so that if an address is in the signature this is used for the connection. It also only converts that address back to a hostname if it wasn't included in the Signature.

Previously this would have used the hostname and ignored the address - note this cannot change any existing code because before it wasn't possible to create a Signature with both address and hostname.

I also think its a bit clearly whats going on in the function as before the ordering of checks was complicated with nested ifs and guards.

There are a couple of bonus commits :)
- 114f6b9 updates the status flag in a number of cases it would otherwise not have been, but pretty sure this makes sense - although it there are probably other places that are not handled, seems this flag probably isn't very reliable.

## Motivation and Context
The main motivation was that I need to resolve a hostname early on, and use that address to make a connection later and still have TLS work.

## How Has This Been Tested?
I have tested and used these changes on both iOS and MacOS

## Checklist:
- [X] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [N/A] If applicable, I have updated the documentation accordingly.
- [N/A] If applicable, I have added tests to cover my changes.
