### PR TITLE
Fix the retrieve of the UNIX address as an UnsafeMutablePointer for b…

### DIFF
--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -692,10 +692,17 @@ public class Socket: SocketReader, SocketWriter {
 			// macOS uses one byte for sa_family_t, Linux uses two...
 			#if os(Linux)
 				let afUnixShort = UInt16(AF_UNIX)
-				addrPtr[memLoc] = UInt8(afUnixShort & 0xFF)
-				memLoc += 1
-				addrPtr[memLoc] = UInt8((afUnixShort >> 8) & 0xFF)
-				memLoc += 1
+			        if isLittleEndian {
+				  addrPtr[memLoc] = UInt8(afUnixShort & 0xFF)
+				  memLoc += 1
+				  addrPtr[memLoc] = UInt8((afUnixShort >> 8) & 0xFF)
+				  memLoc += 1
+				} else {
+				  addrPtr[memLoc] = UInt8((afUnixShort >> 8) & 0xFF)
+				  memLoc += 1
+				  addrPtr[memLoc] = UInt8(afUnixShort & 0xFF)
+				  memLoc += 1
+				}
 			#else
 				addrPtr[memLoc] = UInt8(addrLen)
 				memLoc += 1


### PR DESCRIPTION
…ig endian

<!--- Provide a general summary of your changes in the Title above -->

## Description
When retrieving the UNIX address as an UnsafeMutablePointer, the current code was only for little endian. Therefore, on big endian platform, the field, i.e., `sa_family_t`, of such an UnsafeMutablePointer cannot be correctly recovered. 

## Motivation and Context
The fix is to swap the byte mapping to address of `afUnixShort`, which is an `UInt16` on big endian platform.

## How Has This Been Tested?
Run `swift test`, all tests got passed. Also, failures in `Kitura` because of this issue got fixed after the fix.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
