### PR TITLE
Fix retain cycle

### DIFF
--- a/Sources/Socket/Socket.swift
+++ b/Sources/Socket/Socket.swift
@@ -844,7 +844,7 @@ public class Socket: SocketReader, SocketWriter {
 	///
 	/// The delegate that provides the SSL implementation.
 	///
-	public var delegate: SSLServiceDelegate? = nil {
+	public weak var delegate: SSLServiceDelegate? = nil {
 
 		didSet {
 

--- a/Sources/Socket/SocketProtocols.swift
+++ b/Sources/Socket/SocketProtocols.swift
@@ -87,7 +87,7 @@ public protocol SocketWriter {
 ///
 /// SSL Service Delegate Protocol
 ///
-public protocol SSLServiceDelegate {
+public protocol SSLServiceDelegate : class {
 	
 	///
 	/// Initialize SSL Service


### PR DESCRIPTION
Socket delegate has a strong reference, which is creating a retain cycle, preventing Socket from getting deallocated.
